### PR TITLE
Add automatic code coverage conversion and reporting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,36 @@ xcodebuild build 2>&1 | xcsift --print-warnings
 # Quiet mode - suppress output when build succeeds with no warnings or errors
 swift build 2>&1 | xcsift --quiet
 xcodebuild build 2>&1 | xcsift -q
+
+# Code coverage - automatically converts .profraw/.xcresult to JSON (no manual conversion needed!)
+
+# SPM: auto-detects and converts .profraw files (summary-only by default)
+swift test --enable-code-coverage 2>&1 | xcsift --coverage
+swift test --enable-code-coverage 2>&1 | xcsift -c
+
+# xcodebuild: auto-detects and converts .xcresult bundles (searches DerivedData automatically!)
+# Automatically filters coverage to tested target only
+xcodebuild test -enableCodeCoverage YES 2>&1 | xcsift --coverage
+
+# Show detailed per-file coverage (default is summary-only for token efficiency)
+swift test --enable-code-coverage 2>&1 | xcsift --coverage --coverage-details
+xcodebuild test 2>&1 | xcsift -c --coverage-details
+
+# Specify custom coverage path (optional - auto-detects by default)
+swift test --enable-code-coverage 2>&1 | xcsift --coverage --coverage-path .build/arm64-apple-macosx/debug/codecov
+xcodebuild test 2>&1 | xcsift --coverage --coverage-path path/to/file.xcresult
+
+# Auto-detection and conversion:
+# SPM (.profraw → .profdata → JSON via llvm tools):
+#   - .build/debug/codecov
+#   - .build/arm64-apple-macosx/debug/codecov
+#   - .build/x86_64-apple-macosx/debug/codecov
+#   - .build/arm64-unknown-linux-gnu/debug/codecov
+#   - .build/x86_64-unknown-linux-gnu/debug/codecov
+#
+# xcodebuild (.xcresult → JSON via xcrun xccov):
+#   - ~/Library/Developer/Xcode/DerivedData/**/*.xcresult (searches automatically)
+#   - Current directory/**/*.xcresult
 ```
 
 ## Architecture
@@ -59,9 +89,10 @@ The codebase follows a simple two-component architecture:
 
 2. **OutputParser.swift** - Core parsing logic
    - `OutputParser` class with regex-based line parsing
-   - Defines data structures: `BuildResult`, `BuildSummary`, `BuildError`, `BuildWarning`, `FailedTest`
+   - Defines data structures: `BuildResult`, `BuildSummary`, `BuildError`, `BuildWarning`, `FailedTest`, `CodeCoverage`, `FileCoverage`
    - Pattern matching for various Xcode/SPM output formats
    - Extracts file paths, line numbers, and messages from build output
+   - Parses code coverage data from SPM coverage JSON files
 
 ### Data Flow
 1. Stdin input → `readStandardInput()`
@@ -74,6 +105,19 @@ The codebase follows a simple two-component architecture:
 - **Test Failure Detection**: XCUnit assertion failures and general test failures
 - **Build Time Extraction**: Captures build duration from output
 - **File/Line Mapping**: Extracts precise source locations for navigation
+- **Code Coverage with Auto-Conversion**: Automatically converts coverage files to JSON when `--coverage` flag is used
+  - **Auto-detection**: Searches multiple default paths for both SPM and xcodebuild formats
+  - **Target filtering**: Automatically extracts tested target name from xcodebuild output and filters coverage to that target only
+  - **Summary-only mode** (default): Outputs only line coverage percentage to minimize token usage
+  - **Details mode** (with `--coverage-details`): Includes full per-file coverage data
+  - **SPM auto-conversion**: Finds `.profraw` files, locates test binary, runs `llvm-profdata merge` and `llvm-cov export`
+    - `.profraw` → `.profdata` → JSON (fully automatic)
+  - **xcodebuild auto-conversion**: Finds `.xcresult` bundles, runs `xcrun xccov view --report --json`
+    - `.xcresult` → JSON (fully automatic)
+  - **No manual steps**: Works out of the box with both build systems
+    - SPM: `swift test --enable-code-coverage 2>&1 | xcsift --coverage`
+    - xcodebuild: `xcodebuild test -enableCodeCoverage YES 2>&1 | xcsift --coverage`
+  - Supports both formats seamlessly
 
 ## Testing
 
@@ -84,6 +128,14 @@ Tests are in `Tests/OutputParserTests.swift` using XCTest framework. Test cases 
 - Multi-error scenarios
 - Build time parsing
 - Edge cases (missing files, deprecated functions)
+- Code coverage data structures and parsing
+- JSON encoding with and without coverage data
+- SPM coverage format parsing
+- xcodebuild coverage format parsing (decimal and percentage formats)
+- Format auto-detection
+- Target extraction from xcodebuild output
+- Coverage target filtering
+- Summary-only vs details mode for coverage output
 
 Run individual tests:
 ```bash
@@ -100,8 +152,39 @@ swift test --filter OutputParserTests.testParseError
 
 The tool outputs structured data optimized for coding agents:
 
-- **JSON**: Structured format with `status`, `summary`, `errors`, `warnings` (optional), `failed_tests`
+- **JSON**: Structured format with `status`, `summary`, `errors`, `warnings` (optional), `failed_tests`, `coverage` (optional)
   - **Summary always includes warning count**: `{"summary": {"warnings": N, ...}}`
+  - **Summary includes coverage percentage** (when `--coverage` flag is used): `{"summary": {"coverage_percent": X.X, ...}}`
   - **Detailed warnings list** (with `--print-warnings` flag): `{"warnings": [{"file": "...", "line": N, "message": "..."}]}`
   - **Default behavior** (without flag): Only shows warning count in summary, omits detailed warnings array to reduce token usage
   - **Quiet mode** (with `--quiet` or `-q` flag): Produces no output when build succeeds with zero warnings and zero errors
+  - **Coverage data** (with `--coverage` flag):
+    - **Summary-only mode** (default - token-efficient): Only includes coverage percentage in summary
+      ```json
+      {
+        "summary": {
+          "coverage_percent": 85.5
+        }
+      }
+      ```
+    - **Details mode** (with `--coverage-details` flag): Includes per-file coverage details
+      ```json
+      {
+        "coverage": {
+          "line_coverage": 85.5,
+          "files": [
+            {
+              "path": "/path/to/file.swift",
+              "name": "file.swift",
+              "line_coverage": 92.5,
+              "covered_lines": 37,
+              "executable_lines": 40
+            }
+          ]
+        }
+      }
+      ```
+    - **Target filtering** (xcodebuild only): Automatically extracts tested target from stdout and filters coverage to that target only
+    - Supports both SPM (`swift test --enable-code-coverage`) and xcodebuild (`-enableCodeCoverage YES`) formats
+    - Automatically detects format and parses accordingly
+    - Warns to stderr if target was detected but no matching coverage data found

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
             name: "xcsift",
             dependencies: [
                 .product(name: "ArgumentParser", package: "swift-argument-parser")
-            ],
+            ]
         ),
         .testTarget(
             name: "xcsiftTests",

--- a/Sources/OutputParser.swift
+++ b/Sources/OutputParser.swift
@@ -7,20 +7,24 @@ struct BuildResult: Codable {
     let errors: [BuildError]
     let warnings: [BuildWarning]
     let failedTests: [FailedTest]
+    let coverage: CodeCoverage?
     let printWarnings: Bool
+    let printCoverageDetails: Bool
 
     enum CodingKeys: String, CodingKey {
-        case status, summary, errors, warnings
+        case status, summary, errors, warnings, coverage
         case failedTests = "failed_tests"
     }
 
-    init(status: String, summary: BuildSummary, errors: [BuildError], warnings: [BuildWarning], failedTests: [FailedTest], printWarnings: Bool) {
+    init(status: String, summary: BuildSummary, errors: [BuildError], warnings: [BuildWarning], failedTests: [FailedTest], coverage: CodeCoverage?, printWarnings: Bool, printCoverageDetails: Bool = false) {
         self.status = status
         self.summary = summary
         self.errors = errors
         self.warnings = warnings
         self.failedTests = failedTests
+        self.coverage = coverage
         self.printWarnings = printWarnings
+        self.printCoverageDetails = printCoverageDetails
     }
 
     init(from decoder: Decoder) throws {
@@ -30,7 +34,9 @@ struct BuildResult: Codable {
         errors = try container.decodeIfPresent([BuildError].self, forKey: .errors) ?? []
         warnings = try container.decodeIfPresent([BuildWarning].self, forKey: .warnings) ?? []
         failedTests = try container.decodeIfPresent([FailedTest].self, forKey: .failedTests) ?? []
-        printWarnings = false  // Default value for decoding
+        coverage = try container.decodeIfPresent(CodeCoverage.self, forKey: .coverage)
+        printWarnings = false
+        printCoverageDetails = false
     }
 
     func encode(to encoder: Encoder) throws {
@@ -49,6 +55,12 @@ struct BuildResult: Codable {
         if !failedTests.isEmpty {
             try container.encode(failedTests, forKey: .failedTests)
         }
+
+        // Only output coverage section in details mode
+        // In summary-only mode, coverage_percent in summary is sufficient
+        if let coverage = coverage, printCoverageDetails {
+            try container.encode(coverage, forKey: .coverage)
+        }
     }
 }
 
@@ -58,6 +70,7 @@ struct BuildSummary: Codable {
     let failedTests: Int
     let passedTests: Int?
     let buildTime: String?
+    let coveragePercent: Double?
 
     enum CodingKeys: String, CodingKey {
         case errors
@@ -65,6 +78,7 @@ struct BuildSummary: Codable {
         case failedTests = "failed_tests"
         case passedTests = "passed_tests"
         case buildTime = "build_time"
+        case coveragePercent = "coverage_percent"
     }
 }
 
@@ -85,6 +99,32 @@ struct FailedTest: Codable {
     let message: String
     let file: String?
     let line: Int?
+}
+
+struct CodeCoverage: Codable {
+    let lineCoverage: Double
+    let files: [FileCoverage]
+
+    enum CodingKeys: String, CodingKey {
+        case lineCoverage = "line_coverage"
+        case files
+    }
+}
+
+struct FileCoverage: Codable {
+    let path: String
+    let name: String
+    let lineCoverage: Double
+    let coveredLines: Int
+    let executableLines: Int
+
+    enum CodingKeys: String, CodingKey {
+        case path
+        case name
+        case lineCoverage = "line_coverage"
+        case coveredLines = "covered_lines"
+        case executableLines = "executable_lines"
+    }
 }
 
 class OutputParser {
@@ -108,7 +148,7 @@ class OutputParser {
         // TODO: Test if SwiftLint detects this TODO comment
     }
     
-    func parse(input: String, printWarnings: Bool = false) -> BuildResult {
+    func parse(input: String, printWarnings: Bool = false, coverage: CodeCoverage? = nil, printCoverageDetails: Bool = false) -> BuildResult {
         resetState()
         let lines = input.split(separator: "\n", omittingEmptySubsequences: false)
 
@@ -133,7 +173,8 @@ class OutputParser {
             warnings: warnings.count,
             failedTests: failedTests.count,
             passedTests: computedPassedTests,
-            buildTime: buildTime
+            buildTime: buildTime,
+            coveragePercent: coverage?.lineCoverage
         )
 
         return BuildResult(
@@ -142,10 +183,42 @@ class OutputParser {
             errors: errors,
             warnings: warnings,
             failedTests: failedTests,
-            printWarnings: printWarnings
+            coverage: coverage,
+            printWarnings: printWarnings,
+            printCoverageDetails: printCoverageDetails
         )
     }
-    
+
+    func extractTestedTarget(from input: String) -> String? {
+        let lines = input.split(separator: "\n")
+
+        for line in lines {
+            let lineStr = String(line)
+
+            // Only match lines with .xctest to skip "All tests" and individual test classes
+            if lineStr.contains("Test Suite '") && lineStr.contains(".xctest") && lineStr.contains("started") {
+                let pattern = Regex {
+                    "Test Suite '"
+                    Capture {
+                        OneOrMore(.any, .reluctant)
+                    }
+                    ".xctest"
+                    "'"
+                }
+
+                if let match = lineStr.firstMatch(of: pattern) {
+                    var targetName = String(match.1)
+                    if targetName.hasSuffix("Tests") {
+                        targetName = String(targetName.dropLast(5))
+                    }
+                    return targetName
+                }
+            }
+        }
+
+        return nil
+    }
+
     private func resetState() {
         errors = []
         warnings = []
@@ -701,5 +774,410 @@ class OutputParser {
         }
 
         return nil
+    }
+
+    // MARK: - Code Coverage Parsing
+
+    // MARK: - Coverage Auto-Conversion Helpers
+
+    /// Runs a shell command and returns the output
+    private static func runShellCommand(_ command: String, args: [String]) -> String? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = [command] + args
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+
+        do {
+            try process.run()
+
+            // Read data BEFORE waiting for exit to avoid pipe deadlock
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            process.waitUntilExit()
+
+            guard process.terminationStatus == 0 else {
+                return nil
+            }
+
+            return String(data: data, encoding: .utf8)
+        } catch {
+            return nil
+        }
+    }
+
+    /// Finds all .profraw files in a directory (recursively)
+    private static func findProfrawFiles(in directory: String) -> [String] {
+        let fileManager = FileManager.default
+        guard let enumerator = fileManager.enumerator(atPath: directory) else {
+            return []
+        }
+
+        var profrawFiles: [String] = []
+        for case let file as String in enumerator {
+            if file.hasSuffix(".profraw") {
+                let fullPath = (directory as NSString).appendingPathComponent(file)
+                profrawFiles.append(fullPath)
+            }
+        }
+        return profrawFiles
+    }
+
+    /// Finds the test binary (.xctest bundle) in .build directory
+    private static func findTestBinary() -> String? {
+        let fileManager = FileManager.default
+        let buildDir = ".build"
+
+        guard fileManager.fileExists(atPath: buildDir),
+              let enumerator = fileManager.enumerator(atPath: buildDir) else {
+            return nil
+        }
+
+        for case let file as String in enumerator {
+            if file.hasSuffix(".xctest") {
+                let xctestPath = (buildDir as NSString).appendingPathComponent(file)
+                let macosPath = (xctestPath as NSString).appendingPathComponent("Contents/MacOS")
+
+                guard let macosContents = try? fileManager.contentsOfDirectory(atPath: macosPath) else {
+                    continue
+                }
+
+                for item in macosContents {
+                    let itemPath = (macosPath as NSString).appendingPathComponent(item)
+                    var isDirectory: ObjCBool = false
+
+                    if fileManager.fileExists(atPath: itemPath, isDirectory: &isDirectory),
+                       !isDirectory.boolValue,
+                       !item.hasSuffix(".dSYM") {
+                        return itemPath
+                    }
+                }
+            }
+        }
+        return nil
+    }
+
+    /// Converts .profraw files to JSON coverage data
+    private static func convertProfrawToJSON(profrawFiles: [String]) -> CodeCoverage? {
+        guard !profrawFiles.isEmpty else {
+            return nil
+        }
+
+        guard let testBinary = findTestBinary() else {
+            return nil
+        }
+
+        let tempDir = NSTemporaryDirectory()
+        let profdataPath = (tempDir as NSString).appendingPathComponent("xcsift-coverage.profdata")
+        let jsonPath = (tempDir as NSString).appendingPathComponent("xcsift-coverage.json")
+
+        let mergeArgs = ["llvm-profdata", "merge", "-sparse"] + profrawFiles + ["-o", profdataPath]
+        guard runShellCommand("xcrun", args: mergeArgs) != nil else {
+            return nil
+        }
+
+        let exportArgs = ["llvm-cov", "export", testBinary, "-instr-profile=\(profdataPath)", "-format=text"]
+        guard let jsonOutput = runShellCommand("xcrun", args: exportArgs) else {
+            try? FileManager.default.removeItem(atPath: profdataPath)
+            return nil
+        }
+
+        guard let jsonData = jsonOutput.data(using: .utf8) else {
+            try? FileManager.default.removeItem(atPath: profdataPath)
+            return nil
+        }
+
+        do {
+            try jsonData.write(to: URL(fileURLWithPath: jsonPath))
+            let coverage = parseCoverageJSON(at: jsonPath)
+            try? FileManager.default.removeItem(atPath: profdataPath)
+            try? FileManager.default.removeItem(atPath: jsonPath)
+            return coverage
+        } catch {
+            try? FileManager.default.removeItem(atPath: profdataPath)
+            return nil
+        }
+    }
+
+    /// Finds .xcresult bundles (created by xcodebuild)
+    private static func findXCResultBundles(in directory: String) -> [String] {
+        let fileManager = FileManager.default
+        guard let enumerator = fileManager.enumerator(atPath: directory) else {
+            return []
+        }
+
+        var xcresultPaths: [String] = []
+        for case let file as String in enumerator {
+            if file.hasSuffix(".xcresult") {
+                let fullPath = (directory as NSString).appendingPathComponent(file)
+                xcresultPaths.append(fullPath)
+            }
+        }
+        return xcresultPaths
+    }
+
+    /// Finds the most recent .xcresult bundle in Xcode DerivedData using shell find
+    private static func findLatestXCResultInDerivedData() -> String? {
+        let fileManager = FileManager.default
+        let homeDir = fileManager.homeDirectoryForCurrentUser.path
+        let derivedDataPath = (homeDir as NSString).appendingPathComponent("Library/Developer/Xcode/DerivedData")
+
+        guard fileManager.fileExists(atPath: derivedDataPath) else {
+            return nil
+        }
+
+        let findArgs = ["find", derivedDataPath, "-name", "*.xcresult", "-type", "d", "-mtime", "-7"]
+        guard let output = runShellCommand("/usr/bin/env", args: findArgs) else {
+            return nil
+        }
+
+        let paths = output.components(separatedBy: .newlines).filter { !$0.isEmpty }
+        guard !paths.isEmpty else {
+            return nil
+        }
+
+        var newestBundle: String?
+        var newestDate: Date?
+
+        for path in paths {
+            if let attrs = try? fileManager.attributesOfItem(atPath: path),
+               let modDate = attrs[.modificationDate] as? Date {
+                if newestDate == nil || modDate > newestDate! {
+                    newestDate = modDate
+                    newestBundle = path
+                }
+            }
+        }
+
+        return newestBundle
+    }
+
+    /// Converts .xcresult bundle to JSON coverage data
+    private static func convertXCResultToJSON(xcresultPath: String, targetFilter: String? = nil) -> CodeCoverage? {
+        let args = ["xccov", "view", "--report", "--json", xcresultPath]
+        guard let jsonOutput = runShellCommand("xcrun", args: args) else {
+            return nil
+        }
+
+        guard let jsonData = jsonOutput.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any] else {
+            return nil
+        }
+
+        return parseXcodebuildFormat(json: json, targetFilter: targetFilter)
+    }
+
+    static func parseCoverageFromPath(_ path: String, targetFilter: String? = nil) -> CodeCoverage? {
+        let fileManager = FileManager.default
+        let coveragePath: String
+
+        // If explicit path provided and exists, use it
+        if !path.isEmpty && fileManager.fileExists(atPath: path) {
+            coveragePath = path
+        } else {
+            // Auto-detect: try xcodebuild first (DerivedData), then SPM paths
+            if let latestXCResult = findLatestXCResultInDerivedData() {
+                return convertXCResultToJSON(xcresultPath: latestXCResult, targetFilter: targetFilter)
+            }
+
+            let defaultPaths = [
+                ".build/debug/codecov",
+                ".build/arm64-apple-macosx/debug/codecov",
+                ".build/x86_64-apple-macosx/debug/codecov",
+                ".build/arm64-unknown-linux-gnu/debug/codecov",
+                ".build/x86_64-unknown-linux-gnu/debug/codecov",
+                "DerivedData",
+                "."
+            ]
+
+            var foundPath: String?
+            for defaultPath in defaultPaths {
+                if fileManager.fileExists(atPath: defaultPath) {
+                    foundPath = defaultPath
+                    break
+                }
+            }
+
+            guard let found = foundPath else {
+                return nil
+            }
+            coveragePath = found
+        }
+
+        guard fileManager.fileExists(atPath: coveragePath) else {
+            return nil
+        }
+
+        var isDirectory: ObjCBool = false
+        fileManager.fileExists(atPath: coveragePath, isDirectory: &isDirectory)
+
+        if isDirectory.boolValue {
+            guard let files = try? fileManager.contentsOfDirectory(atPath: coveragePath) else {
+                return nil
+            }
+
+            let jsonFiles = files.filter { $0.hasSuffix(".json") }
+            if let firstJsonFile = jsonFiles.first {
+                let jsonPath = (coveragePath as NSString).appendingPathComponent(firstJsonFile)
+                return parseCoverageJSON(at: jsonPath, targetFilter: targetFilter)
+            }
+
+            let profrawFiles = findProfrawFiles(in: coveragePath)
+            if !profrawFiles.isEmpty {
+                return convertProfrawToJSON(profrawFiles: profrawFiles)
+            }
+
+            let xcresultBundles = findXCResultBundles(in: coveragePath)
+            if let firstXCResult = xcresultBundles.first {
+                return convertXCResultToJSON(xcresultPath: firstXCResult, targetFilter: targetFilter)
+            }
+
+            if let latestXCResult = findLatestXCResultInDerivedData() {
+                return convertXCResultToJSON(xcresultPath: latestXCResult, targetFilter: targetFilter)
+            }
+
+            return nil
+        } else {
+            if coveragePath.hasSuffix(".xcresult") {
+                return convertXCResultToJSON(xcresultPath: coveragePath, targetFilter: targetFilter)
+            } else {
+                return parseCoverageJSON(at: coveragePath, targetFilter: targetFilter)
+            }
+        }
+    }
+
+    private static func parseCoverageJSON(at path: String, targetFilter: String? = nil) -> CodeCoverage? {
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)) else {
+            return nil
+        }
+
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+
+        if let coverage = parseXcodebuildFormat(json: json, targetFilter: targetFilter) {
+            return coverage
+        }
+
+        if let coverage = parseSPMFormat(json: json) {
+            return coverage
+        }
+
+        return nil
+    }
+
+    private static func parseXcodebuildFormat(json: [String: Any], targetFilter: String? = nil) -> CodeCoverage? {
+        guard let targets = json["targets"] as? [[String: Any]] else {
+            return nil
+        }
+
+        var fileCoverages: [FileCoverage] = []
+        var totalCovered = 0
+        var totalExecutable = 0
+
+        for target in targets {
+            // Get target name if available
+            let targetName = target["name"] as? String
+
+            // Skip test bundles - we want coverage of tested code, not tests themselves
+            if let name = targetName, name.hasSuffix(".xctest") {
+                continue
+            }
+
+            // Apply target filter if specified
+            if let filter = targetFilter, let name = targetName {
+                if !name.contains(filter) && !filter.contains(name) {
+                    continue
+                }
+            }
+
+            guard let filesArray = target["files"] as? [[String: Any]] else {
+                continue
+            }
+
+            for fileData in filesArray {
+                guard let filename = fileData["path"] as? String else {
+                    continue
+                }
+
+                let lineCoverage: Double
+                let covered: Int
+                let executable: Int
+
+                if let coverage = fileData["lineCoverage"] as? Double {
+                    lineCoverage = coverage > 1.0 ? coverage : coverage * 100.0
+                    covered = fileData["coveredLines"] as? Int ?? 0
+                    executable = fileData["executableLines"] as? Int ?? 0
+                } else {
+                    continue
+                }
+
+                let name = (filename as NSString).lastPathComponent
+
+                fileCoverages.append(FileCoverage(
+                    path: filename,
+                    name: name,
+                    lineCoverage: lineCoverage,
+                    coveredLines: covered,
+                    executableLines: executable
+                ))
+
+                totalCovered += covered
+                totalExecutable += executable
+            }
+        }
+
+        guard !fileCoverages.isEmpty else {
+            return nil
+        }
+
+        let overallCoverage = totalExecutable > 0 ? (Double(totalCovered) / Double(totalExecutable)) * 100.0 : 0.0
+
+        return CodeCoverage(lineCoverage: overallCoverage, files: fileCoverages)
+    }
+
+    private static func parseSPMFormat(json: [String: Any]) -> CodeCoverage? {
+        guard let dataArray = json["data"] as? [[String: Any]],
+              let firstData = dataArray.first,
+              let filesArray = firstData["files"] as? [[String: Any]] else {
+            return nil
+        }
+
+        var fileCoverages: [FileCoverage] = []
+        var totalCovered = 0
+        var totalExecutable = 0
+
+        for fileData in filesArray {
+            guard let filename = fileData["filename"] as? String,
+                  let summary = fileData["summary"] as? [String: Any],
+                  let lines = summary["lines"] as? [String: Any],
+                  let covered = lines["covered"] as? Int,
+                  let count = lines["count"] as? Int else {
+                continue
+            }
+
+            let coverage = count > 0 ? (Double(covered) / Double(count)) * 100.0 : 0.0
+            let name = (filename as NSString).lastPathComponent
+
+            fileCoverages.append(FileCoverage(
+                path: filename,
+                name: name,
+                lineCoverage: coverage,
+                coveredLines: covered,
+                executableLines: count
+            ))
+
+            totalCovered += covered
+            totalExecutable += count
+        }
+
+        guard !fileCoverages.isEmpty else {
+            return nil
+        }
+
+        let overallCoverage = totalExecutable > 0 ? (Double(totalCovered) / Double(totalExecutable)) * 100.0 : 0.0
+
+        return CodeCoverage(lineCoverage: overallCoverage, files: fileCoverages)
     }
 }

--- a/Tests/OutputParserTests.swift
+++ b/Tests/OutputParserTests.swift
@@ -344,4 +344,672 @@ final class OutputParserTests: XCTestCase {
         XCTAssertEqual(result.summary.passedTests, 23)
         XCTAssertEqual(result.summary.buildTime, "0.031")
     }
+
+    func testCodeCoverageDataStructures() {
+        // Test that coverage data structures can be created and encoded
+        let fileCoverage = FileCoverage(
+            path: "/path/to/file.swift",
+            name: "file.swift",
+            lineCoverage: 85.5,
+            coveredLines: 50,
+            executableLines: 58
+        )
+
+        let coverage = CodeCoverage(
+            lineCoverage: 75.0,
+            files: [fileCoverage]
+        )
+
+        XCTAssertEqual(coverage.lineCoverage, 75.0)
+        XCTAssertEqual(coverage.files.count, 1)
+        XCTAssertEqual(coverage.files[0].name, "file.swift")
+        XCTAssertEqual(coverage.files[0].lineCoverage, 85.5)
+    }
+
+    func testBuildResultWithCoverage() {
+        let fileCoverage = FileCoverage(
+            path: "/path/to/file.swift",
+            name: "file.swift",
+            lineCoverage: 85.5,
+            coveredLines: 50,
+            executableLines: 58
+        )
+
+        let coverage = CodeCoverage(
+            lineCoverage: 75.0,
+            files: [fileCoverage]
+        )
+
+        let parser = OutputParser()
+        let input = """
+        Building for debugging...
+        Build complete!
+        """
+
+        let result = parser.parse(input: input, coverage: coverage, printCoverageDetails: true)
+
+        XCTAssertEqual(result.status, "success")
+        XCTAssertNotNil(result.coverage)
+        XCTAssertEqual(result.coverage?.lineCoverage, 75.0)
+        XCTAssertEqual(result.summary.coveragePercent, 75.0)
+
+        // Encode to JSON and verify coverage is included in details mode
+        let encoder = JSONEncoder()
+        let jsonData = try! encoder.encode(result)
+        let jsonString = String(data: jsonData, encoding: .utf8)!
+
+        XCTAssertTrue(jsonString.contains("coverage"))
+        XCTAssertTrue(jsonString.contains("line_coverage"))
+        XCTAssertTrue(jsonString.contains("coverage_percent"))
+    }
+
+    func testBuildResultWithoutCoverage() {
+        let parser = OutputParser()
+        let input = """
+        Building for debugging...
+        Build complete!
+        """
+
+        let result = parser.parse(input: input)
+
+        XCTAssertEqual(result.status, "success")
+        XCTAssertNil(result.coverage)
+        XCTAssertNil(result.summary.coveragePercent)
+
+        // Encode to JSON and verify coverage is not included
+        let encoder = JSONEncoder()
+        let jsonData = try! encoder.encode(result)
+        let jsonString = String(data: jsonData, encoding: .utf8)!
+
+        XCTAssertFalse(jsonString.contains("\"coverage\""))
+    }
+
+    func testParseCoverageFromNonExistentPath() {
+        let coverage = OutputParser.parseCoverageFromPath("/nonexistent/path")
+        _ = coverage
+    }
+
+    func testCoverageJSONEncoding() {
+        let fileCoverage = FileCoverage(
+            path: "/Users/test/project/Sources/main.swift",
+            name: "main.swift",
+            lineCoverage: 92.5,
+            coveredLines: 37,
+            executableLines: 40
+        )
+
+        let coverage = CodeCoverage(
+            lineCoverage: 85.0,
+            files: [fileCoverage]
+        )
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .prettyPrinted
+        let jsonData = try! encoder.encode(coverage)
+        let jsonString = String(data: jsonData, encoding: .utf8)!
+
+        // Verify JSON structure
+        XCTAssertTrue(jsonString.contains("\"line_coverage\""))
+        XCTAssertTrue(jsonString.contains("85"))
+        XCTAssertTrue(jsonString.contains("\"files\""))
+        XCTAssertTrue(jsonString.contains("main.swift"))
+        XCTAssertTrue(jsonString.contains("\"covered_lines\""))
+        XCTAssertTrue(jsonString.contains("\"executable_lines\""))
+    }
+
+    func testParseXcodebuildCoverageFormat() throws {
+        // Create a temporary xcodebuild-format coverage file
+        let xcodebuildJSON = """
+        {
+          "targets": [{
+            "name": "MyTarget",
+            "files": [
+              {
+                "path": "/path/to/main.swift",
+                "lineCoverage": 0.90,
+                "coveredLines": 45,
+                "executableLines": 50
+              },
+              {
+                "path": "/path/to/helper.swift",
+                "lineCoverage": 0.80,
+                "coveredLines": 40,
+                "executableLines": 50
+              }
+            ]
+          }]
+        }
+        """
+
+        let tempDir = FileManager.default.temporaryDirectory
+        let testFile = tempDir.appendingPathComponent("xcodebuild-coverage.json")
+        try xcodebuildJSON.write(to: testFile, atomically: true, encoding: .utf8)
+
+        defer {
+            try? FileManager.default.removeItem(at: testFile)
+        }
+
+        // Parse the xcodebuild format
+        let coverage = OutputParser.parseCoverageFromPath(testFile.path)
+
+        XCTAssertNotNil(coverage)
+        XCTAssertEqual(coverage?.files.count, 2)
+
+        // Check overall coverage: (45+40)/(50+50) = 85/100 = 85%
+        XCTAssertEqual(coverage?.lineCoverage ?? 0, 85.0, accuracy: 0.1)
+
+        // Check individual files
+        let mainFile = coverage?.files.first(where: { $0.name == "main.swift" })
+        XCTAssertNotNil(mainFile)
+        XCTAssertEqual(mainFile?.lineCoverage ?? 0, 90.0, accuracy: 0.1)
+        XCTAssertEqual(mainFile?.coveredLines ?? 0, 45)
+        XCTAssertEqual(mainFile?.executableLines, 50)
+    }
+
+    func testParseSPMCoverageFormat() throws {
+        // Create a temporary SPM-format coverage file
+        let spmJSON = """
+        {
+          "data": [{
+            "files": [
+              {
+                "filename": "/path/to/main.swift",
+                "summary": {
+                  "lines": {
+                    "covered": 45,
+                    "count": 50
+                  }
+                }
+              },
+              {
+                "filename": "/path/to/helper.swift",
+                "summary": {
+                  "lines": {
+                    "covered": 40,
+                    "count": 50
+                  }
+                }
+              }
+            ]
+          }]
+        }
+        """
+
+        let tempDir = FileManager.default.temporaryDirectory
+        let testFile = tempDir.appendingPathComponent("spm-coverage.json")
+        try spmJSON.write(to: testFile, atomically: true, encoding: .utf8)
+
+        defer {
+            try? FileManager.default.removeItem(at: testFile)
+        }
+
+        // Parse the SPM format
+        let coverage = OutputParser.parseCoverageFromPath(testFile.path)
+
+        XCTAssertNotNil(coverage)
+        XCTAssertEqual(coverage?.files.count, 2)
+
+        // Check overall coverage: (45+40)/(50+50) = 85/100 = 85%
+        XCTAssertEqual(coverage?.lineCoverage ?? 0, 85.0, accuracy: 0.1)
+
+        // Check individual files
+        let mainFile = coverage?.files.first(where: { $0.name == "main.swift" })
+        XCTAssertNotNil(mainFile)
+        XCTAssertEqual(mainFile?.lineCoverage ?? 0, 90.0, accuracy: 0.1)
+        XCTAssertEqual(mainFile?.coveredLines ?? 0, 45)
+        XCTAssertEqual(mainFile?.executableLines, 50)
+    }
+
+    func testXcodebuildCoverageWithPercentageFormat() throws {
+        // Test xcodebuild format with percentage (85.0) instead of decimal (0.85)
+        let xcodebuildJSON = """
+        {
+          "targets": [{
+            "files": [
+              {
+                "path": "/path/to/main.swift",
+                "lineCoverage": 90.0,
+                "coveredLines": 45,
+                "executableLines": 50
+              }
+            ]
+          }]
+        }
+        """
+
+        let tempDir = FileManager.default.temporaryDirectory
+        let testFile = tempDir.appendingPathComponent("xcodebuild-percent.json")
+        try xcodebuildJSON.write(to: testFile, atomically: true, encoding: .utf8)
+
+        defer {
+            try? FileManager.default.removeItem(at: testFile)
+        }
+
+        let coverage = OutputParser.parseCoverageFromPath(testFile.path)
+
+        XCTAssertNotNil(coverage)
+        XCTAssertEqual(coverage?.lineCoverage ?? 0, 90.0, accuracy: 0.1)
+    }
+
+    func testParseEmptyPathTriggersAutoDetection() {
+        let coverage = OutputParser.parseCoverageFromPath("")
+        _ = coverage
+    }
+
+    func testParseExplicitPathThatExists() throws {
+        let spmJSON = """
+        {
+          "data": [{
+            "files": [
+              {
+                "filename": "/path/to/test.swift",
+                "summary": {
+                  "lines": {
+                    "covered": 10,
+                    "count": 20
+                  }
+                }
+              }
+            ]
+          }]
+        }
+        """
+
+        let tempDir = FileManager.default.temporaryDirectory
+        let testFile = tempDir.appendingPathComponent("explicit-coverage.json")
+        try spmJSON.write(to: testFile, atomically: true, encoding: .utf8)
+
+        defer {
+            try? FileManager.default.removeItem(at: testFile)
+        }
+
+        let coverage = OutputParser.parseCoverageFromPath(testFile.path)
+
+        XCTAssertNotNil(coverage)
+        XCTAssertEqual(coverage?.lineCoverage ?? 0, 50.0, accuracy: 0.1)
+    }
+
+    func testParseXCResultPathDirectly() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+        let xcresultPath = tempDir.appendingPathComponent("test.xcresult")
+
+        try FileManager.default.createDirectory(at: xcresultPath, withIntermediateDirectories: true)
+
+        defer {
+            try? FileManager.default.removeItem(at: xcresultPath)
+        }
+
+        let coverage = OutputParser.parseCoverageFromPath(xcresultPath.path)
+        _ = coverage
+    }
+
+    func testMultipleFilesInCoverageCalculation() throws {
+        let spmJSON = """
+        {
+          "data": [{
+            "files": [
+              {
+                "filename": "/path/to/file1.swift",
+                "summary": {
+                  "lines": {
+                    "covered": 80,
+                    "count": 100
+                  }
+                }
+              },
+              {
+                "filename": "/path/to/file2.swift",
+                "summary": {
+                  "lines": {
+                    "covered": 40,
+                    "count": 100
+                  }
+                }
+              },
+              {
+                "filename": "/path/to/file3.swift",
+                "summary": {
+                  "lines": {
+                    "covered": 60,
+                    "count": 100
+                  }
+                }
+              }
+            ]
+          }]
+        }
+        """
+
+        let tempDir = FileManager.default.temporaryDirectory
+        let testFile = tempDir.appendingPathComponent("multi-file-coverage.json")
+        try spmJSON.write(to: testFile, atomically: true, encoding: .utf8)
+
+        defer {
+            try? FileManager.default.removeItem(at: testFile)
+        }
+
+        let coverage = OutputParser.parseCoverageFromPath(testFile.path)
+
+        XCTAssertNotNil(coverage)
+        XCTAssertEqual(coverage?.files.count, 3)
+
+        // Overall: (80+40+60)/(100+100+100) = 180/300 = 60%
+        XCTAssertEqual(coverage?.lineCoverage ?? 0, 60.0, accuracy: 0.1)
+    }
+
+    func testInvalidJSONReturnsNil() throws {
+        let invalidJSON = """
+        {
+          "invalid": "format"
+        }
+        """
+
+        let tempDir = FileManager.default.temporaryDirectory
+        let testFile = tempDir.appendingPathComponent("invalid-coverage.json")
+        try invalidJSON.write(to: testFile, atomically: true, encoding: .utf8)
+
+        defer {
+            try? FileManager.default.removeItem(at: testFile)
+        }
+
+        let coverage = OutputParser.parseCoverageFromPath(testFile.path)
+
+        XCTAssertNil(coverage)
+    }
+
+    func testEmptyFilesArrayReturnsNil() throws {
+        let emptyJSON = """
+        {
+          "data": [{
+            "files": []
+          }]
+        }
+        """
+
+        let tempDir = FileManager.default.temporaryDirectory
+        let testFile = tempDir.appendingPathComponent("empty-coverage.json")
+        try emptyJSON.write(to: testFile, atomically: true, encoding: .utf8)
+
+        defer {
+            try? FileManager.default.removeItem(at: testFile)
+        }
+
+        let coverage = OutputParser.parseCoverageFromPath(testFile.path)
+
+        XCTAssertNil(coverage)
+    }
+
+    func testXcodebuildFormatWithDecimalCoverage() throws {
+        let xcodebuildJSON = """
+        {
+          "targets": [{
+            "files": [
+              {
+                "path": "/path/to/main.swift",
+                "lineCoverage": 0.85,
+                "coveredLines": 85,
+                "executableLines": 100
+              }
+            ]
+          }]
+        }
+        """
+
+        let tempDir = FileManager.default.temporaryDirectory
+        let testFile = tempDir.appendingPathComponent("xcodebuild-decimal.json")
+        try xcodebuildJSON.write(to: testFile, atomically: true, encoding: .utf8)
+
+        defer {
+            try? FileManager.default.removeItem(at: testFile)
+        }
+
+        let coverage = OutputParser.parseCoverageFromPath(testFile.path)
+
+        XCTAssertNotNil(coverage)
+        XCTAssertEqual(coverage?.lineCoverage ?? 0, 85.0, accuracy: 0.1)
+    }
+
+    func testZeroCoverageHandling() throws {
+        let spmJSON = """
+        {
+          "data": [{
+            "files": [
+              {
+                "filename": "/path/to/uncovered.swift",
+                "summary": {
+                  "lines": {
+                    "covered": 0,
+                    "count": 50
+                  }
+                }
+              }
+            ]
+          }]
+        }
+        """
+
+        let tempDir = FileManager.default.temporaryDirectory
+        let testFile = tempDir.appendingPathComponent("zero-coverage.json")
+        try spmJSON.write(to: testFile, atomically: true, encoding: .utf8)
+
+        defer {
+            try? FileManager.default.removeItem(at: testFile)
+        }
+
+        let coverage = OutputParser.parseCoverageFromPath(testFile.path)
+
+        XCTAssertNotNil(coverage)
+        XCTAssertEqual(coverage?.lineCoverage ?? -1, 0.0, accuracy: 0.01)
+        XCTAssertEqual(coverage?.files.first?.lineCoverage ?? -1, 0.0, accuracy: 0.01)
+    }
+
+    func testFullCoverageHandling() throws {
+        let spmJSON = """
+        {
+          "data": [{
+            "files": [
+              {
+                "filename": "/path/to/perfect.swift",
+                "summary": {
+                  "lines": {
+                    "covered": 100,
+                    "count": 100
+                  }
+                }
+              }
+            ]
+          }]
+        }
+        """
+
+        let tempDir = FileManager.default.temporaryDirectory
+        let testFile = tempDir.appendingPathComponent("full-coverage.json")
+        try spmJSON.write(to: testFile, atomically: true, encoding: .utf8)
+
+        defer {
+            try? FileManager.default.removeItem(at: testFile)
+        }
+
+        let coverage = OutputParser.parseCoverageFromPath(testFile.path)
+
+        XCTAssertNotNil(coverage)
+        XCTAssertEqual(coverage?.lineCoverage ?? 0, 100.0, accuracy: 0.01)
+        XCTAssertEqual(coverage?.files.first?.lineCoverage ?? 0, 100.0, accuracy: 0.01)
+    }
+
+    func testExtractTestedTarget() {
+        let parser = OutputParser()
+        let input = """
+        Test Suite 'MyAppTests.xctest' started at 2025-01-05 10:30:00.000
+        Test Suite 'LoginTests' started at 2025-01-05 10:30:00.100
+        """
+
+        let target = parser.extractTestedTarget(from: input)
+
+        XCTAssertNotNil(target)
+        XCTAssertEqual(target, "MyApp")
+    }
+
+    func testExtractTestedTargetSkipsAllTests() {
+        let parser = OutputParser()
+        let input = """
+        Test Suite 'All tests' started at 2025-01-05 10:30:00.000
+        Test Suite 'SampleAppTests.xctest' started at 2025-01-05 10:30:00.100
+        """
+
+        let target = parser.extractTestedTarget(from: input)
+
+        XCTAssertNotNil(target)
+        XCTAssertEqual(target, "SampleApp")
+    }
+
+    func testExtractTestedTargetNotFound() {
+        let parser = OutputParser()
+        let input = """
+        Building for debugging...
+        Build complete!
+        """
+
+        let target = parser.extractTestedTarget(from: input)
+
+        XCTAssertNil(target)
+    }
+
+    func testCoverageTargetFiltering() throws {
+        let xcodebuildJSON = """
+        {
+          "targets": [
+            {
+              "name": "MyApp.app",
+              "files": [
+                {
+                  "path": "/path/to/MyFile.swift",
+                  "lineCoverage": 0.85,
+                  "coveredLines": 85,
+                  "executableLines": 100
+                }
+              ]
+            },
+            {
+              "name": "OtherApp.app",
+              "files": [
+                {
+                  "path": "/path/to/OtherFile.swift",
+                  "lineCoverage": 0.50,
+                  "coveredLines": 50,
+                  "executableLines": 100
+                }
+              ]
+            }
+          ]
+        }
+        """
+
+        let tempDir = FileManager.default.temporaryDirectory
+        let testFile = tempDir.appendingPathComponent("filtered-coverage.json")
+        try xcodebuildJSON.write(to: testFile, atomically: true, encoding: .utf8)
+
+        defer {
+            try? FileManager.default.removeItem(at: testFile)
+        }
+
+        let coverage = OutputParser.parseCoverageFromPath(testFile.path, targetFilter: "MyApp")
+
+        XCTAssertNotNil(coverage)
+        XCTAssertEqual(coverage?.files.count, 1)
+        XCTAssertEqual(coverage?.files.first?.name, "MyFile.swift")
+        XCTAssertEqual(coverage?.lineCoverage ?? 0, 85.0, accuracy: 0.01)
+    }
+
+    func testCoverageExcludesTestBundles() throws {
+        let xcodebuildJSON = """
+        {
+          "targets": [
+            {
+              "name": "MyModule.framework",
+              "files": [
+                {
+                  "path": "/path/to/MyFile.swift",
+                  "lineCoverage": 0.50,
+                  "coveredLines": 50,
+                  "executableLines": 100
+                }
+              ]
+            },
+            {
+              "name": "MyModuleTests.xctest",
+              "files": [
+                {
+                  "path": "/path/to/MyModuleTests.swift",
+                  "lineCoverage": 1.0,
+                  "coveredLines": 100,
+                  "executableLines": 100
+                }
+              ]
+            }
+          ]
+        }
+        """
+
+        let tempDir = FileManager.default.temporaryDirectory
+        let testFile = tempDir.appendingPathComponent("exclude-tests-coverage.json")
+        try xcodebuildJSON.write(to: testFile, atomically: true, encoding: .utf8)
+
+        defer {
+            try? FileManager.default.removeItem(at: testFile)
+        }
+
+        let coverage = OutputParser.parseCoverageFromPath(testFile.path, targetFilter: "MyModule")
+
+        XCTAssertNotNil(coverage)
+        XCTAssertEqual(coverage?.files.count, 1)
+        XCTAssertEqual(coverage?.files.first?.name, "MyFile.swift")
+        XCTAssertEqual(coverage?.lineCoverage ?? 0, 50.0, accuracy: 0.01)
+    }
+
+    func testCoverageSummaryOnlyMode() throws {
+        let parser = OutputParser()
+        let input = "Build complete!"
+        let coverage = CodeCoverage(
+            lineCoverage: 75.5,
+            files: [
+                FileCoverage(path: "/path/to/file.swift", name: "file.swift", lineCoverage: 75.5, coveredLines: 75, executableLines: 100)
+            ]
+        )
+
+        let result = parser.parse(input: input, printWarnings: false, coverage: coverage, printCoverageDetails: false)
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .prettyPrinted
+        let jsonData = try encoder.encode(result)
+        let jsonString = String(data: jsonData, encoding: .utf8)!
+
+        XCTAssertTrue(jsonString.contains("\"coverage_percent\""))
+        XCTAssertFalse(jsonString.contains("\"line_coverage\""))
+        XCTAssertFalse(jsonString.contains("\"files\""))
+        XCTAssertTrue(jsonString.contains("75.5"))
+    }
+
+    func testCoverageDetailsMode() throws {
+        let parser = OutputParser()
+        let input = "Build complete!"
+        let coverage = CodeCoverage(
+            lineCoverage: 75.5,
+            files: [
+                FileCoverage(path: "/path/to/file.swift", name: "file.swift", lineCoverage: 75.5, coveredLines: 75, executableLines: 100)
+            ]
+        )
+
+        let result = parser.parse(input: input, printWarnings: false, coverage: coverage, printCoverageDetails: true)
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .prettyPrinted
+        let jsonData = try encoder.encode(result)
+        let jsonString = String(data: jsonData, encoding: .utf8)!
+
+        XCTAssertTrue(jsonString.contains("\"line_coverage\""))
+        XCTAssertTrue(jsonString.contains("\"files\""))
+        XCTAssertTrue(jsonString.contains("\"path\""))
+        XCTAssertTrue(jsonString.contains("file.swift"))
+    }
 }


### PR DESCRIPTION
 ## Added automatic code coverage filtering by tested target and output optimization for token efficiency.

### Coverage Filtering:
  - Auto-extract target name from xcodebuild output
  - Filter coverage to tested target only (excluding dependencies)
  - Exclude test bundles (.xctest) from calculation - only measure coverage of tested code, not tests themselves

### Token Optimization:
  - Summary-only mode by default: only summary.coverage_percent, no coverage section
  - New --coverage-details flag for full output with files array

### Error Handling:
  - Warning to stderr when target detected but no matching coverage data found

### Usage

#### Default: summary only (token-efficient)
`xcodebuild test -enableCodeCoverage YES 2>&1 | xcsift --coverage`

#### Detailed per-file coverage
`xcodebuild test 2>&1 | xcsift --coverage --coverage-details`

### Tests
- 6 new tests for target extraction, filtering, and summary/details modes
- All existing tests pass