### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,22 @@ brew install xcsift
 brew install https://raw.githubusercontent.com/ldomaradzki/xcsift/master/homebrew-formula/xcsift.rb
 ```
 
-### Option 2: Download Pre-built Binary
+### Option 2: mise ubi
+
+If you use [mise](https://mise.jdx.dev/) for managing development tools:
+
+```bash
+# Install using ubi plugin
+mise use -g ubi:ldomaradzki/xcsift
+
+# Or add to your .mise.toml
+# [tools]
+# "ubi:ldomaradzki/xcsift" = "latest"
+```
+
+This will automatically download the latest binary from GitHub releases.
+
+### Option 3: Download Pre-built Binary
 
 Download the latest release from [GitHub Releases](https://github.com/ldomaradzki/xcsift/releases):
 
@@ -45,7 +60,7 @@ xattr -d com.apple.quarantine /usr/local/bin/xcsift
 
 > **Note**: This binary is not code-signed with an Apple Developer ID certificate. macOS will show a security warning when first running it. The `xattr` command above removes the quarantine flag. For open source projects, Apple's $99/year Developer Program is required for code signing - there are no free alternatives for macOS.
 
-### Option 3: Build from Source
+### Option 4: Build from Source
 
 ```bash
 git clone https://github.com/ldomaradzki/xcsift.git


### PR DESCRIPTION
This pull request updates the installation instructions in the `README.md` to add support for installing `xcsift` using the `mise` tool, clarifies the available installation options, and renumbers the build-from-source section. The most important changes are grouped below:

Installation options update:

* Added a new section describing how to install `xcsift` using the `mise` tool and its `ubi` plugin, including usage examples and configuration for `.mise.toml`.
* Renamed and renumbered the installation options to accommodate the new `mise` method, moving "Download Pre-built Binary" to Option 3 and "Build from Source" to Option 4. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L29-R44) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L48-R63)

Documentation clarity:

* Improved instructions to clarify that the `mise` method automatically downloads the latest binary from GitHub releases.