### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,17 +30,17 @@ brew install xcsift
 brew install https://raw.githubusercontent.com/ldomaradzki/xcsift/master/homebrew-formula/xcsift.rb
 ```
 
-### Option 2: mise ubi
+### Option 2: mise
 
 If you use [mise](https://mise.jdx.dev/) for managing development tools:
 
 ```bash
-# Install using ubi plugin
-mise use -g ubi:ldomaradzki/xcsift
+# Install from mise registry
+mise use -g xcsift
 
 # Or add to your .mise.toml
 # [tools]
-# "ubi:ldomaradzki/xcsift" = "latest"
+# xcsift = "latest"
 ```
 
 This will automatically download the latest binary from GitHub releases.


### PR DESCRIPTION
 ## Summary

Updates installation instructions for mise now that xcsift has been added to the official mise registry.

## Changes

- Simplified mise installation from `mise use -g ubi:ldomaradzki/xcsift` to `mise use -g xcsift`
- Updated `.mise.toml` example to use the simpler registry format
- Removed "ubi plugin" reference as it's now available directly from the registry

## Context

PR #6923was merged into mise registry, making xcsift available as an official tool entry. 
Users can now install xcsift more easily without specifying the ubi backend.

 ## Related

- mise registry PR: https://github.com/jdx/mise/pull/6923
- mise release 2025.11.4: https://github.com/jdx/mise/pull/6925