### PR TITLE
Add -W/--Werror flag to treat warnings as errors

### DIFF
--- a/Sources/OutputParser.swift
+++ b/Sources/OutputParser.swift
@@ -147,8 +147,8 @@ class OutputParser {
         let unusedVariable = "This variable is never used and will cause a warning"
         // TODO: Test if SwiftLint detects this TODO comment
     }
-    
-    func parse(input: String, printWarnings: Bool = false, coverage: CodeCoverage? = nil, printCoverageDetails: Bool = false) -> BuildResult {
+
+    func parse(input: String, printWarnings: Bool = false, warningsAsErrors: Bool = false, coverage: CodeCoverage? = nil, printCoverageDetails: Bool = false) -> BuildResult {
         resetState()
         let lines = input.split(separator: "\n", omittingEmptySubsequences: false)
 
@@ -156,7 +156,24 @@ class OutputParser {
             parseLine(String(line))
         }
 
-        let status = errors.isEmpty && failedTests.isEmpty ? "success" : "failed"
+        // If warnings-as-errors is enabled, convert warnings to errors
+        var finalErrors = errors
+        var finalWarnings = warnings
+
+        if warningsAsErrors && !warnings.isEmpty {
+            // Convert warnings to errors
+            for warning in warnings {
+                finalErrors.append(BuildError(
+                    file: warning.file,
+                    line: warning.line,
+                    message: warning.message
+                ))
+            }
+            finalWarnings = []
+        }
+
+        let status = finalErrors.isEmpty && failedTests.isEmpty ? "success" : "failed"
+
         let summaryFailedCount = summaryFailedTestsCount ?? failedTests.count
         let computedPassedTests: Int? = {
             if let executed = executedTestsCount {
@@ -169,8 +186,8 @@ class OutputParser {
         }()
 
         let summary = BuildSummary(
-            errors: errors.count,
-            warnings: warnings.count,
+            errors: finalErrors.count,
+            warnings: finalWarnings.count,
             failedTests: failedTests.count,
             passedTests: computedPassedTests,
             buildTime: buildTime,
@@ -180,8 +197,8 @@ class OutputParser {
         return BuildResult(
             status: status,
             summary: summary,
-            errors: errors,
-            warnings: warnings,
+            errors: finalErrors,
+            warnings: finalWarnings,
             failedTests: failedTests,
             coverage: coverage,
             printWarnings: printWarnings,

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -15,7 +15,7 @@ struct XCSift: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "xcsift",
         abstract: "A Swift tool to parse and format xcodebuild output for coding agents",
-        usage: "xcodebuild [options] 2>&1 | xcsift [--warnings|-w] [--quiet|-q] [--coverage|-c] [--version|-v] [--help|-h]",
+        usage: "xcodebuild [options] 2>&1 | xcsift [--warnings|-w] [--Werror|-W] [--quiet|-q] [--coverage|-c] [--version|-v] [--help|-h]",
         discussion: """
         xcsift reads xcodebuild output from stdin and outputs structured JSON.
 
@@ -28,6 +28,7 @@ struct XCSift: ParsableCommand {
           swift build 2>&1 | xcsift --warnings
           swift test 2>&1 | xcsift
           swift build 2>&1 | xcsift --quiet
+          swift build 2>&1 | xcsift --Werror
           swift test --enable-code-coverage 2>&1 | xcsift --coverage
           xcodebuild test -enableCodeCoverage YES 2>&1 | xcsift --coverage
           xcsift -c --coverage-path .build/debug/codecov
@@ -40,6 +41,9 @@ struct XCSift: ParsableCommand {
 
     @Flag(name: [.short, .long], help: "Print detailed warnings list (by default only warning count is shown)")
     var warnings: Bool = false
+
+    @Flag(name: [.customShort("W"), .customLong("Werror")], help: "Treat warnings as errors (build fails if warnings present)")
+    var warningsAsErrors: Bool = false
 
     @Flag(name: [.short, .long], help: "Suppress output when build succeeds with no warnings or errors")
     var quiet: Bool = false
@@ -85,7 +89,7 @@ struct XCSift: ParsableCommand {
             }
         }
 
-        let result = parser.parse(input: input, printWarnings: warnings, coverage: coverageData, printCoverageDetails: coverageDetails)
+        let result = parser.parse(input: input, printWarnings: warnings, warningsAsErrors: warningsAsErrors, coverage: coverageData, printCoverageDetails: coverageDetails)
         outputResult(result, quiet: quiet)
     }
     


### PR DESCRIPTION
When enabled, warnings are converted to errors in the JSON output, causing the build status to be "failed" if any warnings are present.