### PR TITLE
Update documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,10 @@ xcodebuild build 2>&1 | xcsift --warnings
 swift build 2>&1 | xcsift --quiet
 xcodebuild build 2>&1 | xcsift -q
 
+# Werror mode - treat warnings as errors (build fails if warnings present)
+swift build 2>&1 | xcsift --Werror
+xcodebuild build 2>&1 | xcsift -W
+
 # Code coverage - automatically converts .profraw/.xcresult to JSON (no manual conversion needed!)
 
 # SPM: auto-detects and converts .profraw files (summary-only by default)
@@ -127,7 +131,7 @@ swift build 2>&1 | xcsift --format toon --toon-length-marker hash
 xcodebuild test 2>&1 | xcsift -f toon --toon-delimiter tab --toon-length-marker hash -w -c
 swift test 2>&1 | xcsift -f toon --toon-delimiter pipe --toon-length-marker hash --coverage-details
 
-# TOON 3.0 Key Folding - collapses nested single-key objects into dotted paths
+# TOON Key Folding - collapses nested single-key objects into dotted paths
 # Key folding options (default: disabled):
 # - disabled: Normal nested output (default)
 # - safe: Collapses {a:{b:{c:1}}} → a.b.c: 1 when all keys are valid identifiers
@@ -140,7 +144,7 @@ swift build 2>&1 | xcsift --format toon --toon-key-folding safe
 xcodebuild build 2>&1 | xcsift -f toon --toon-key-folding safe --toon-flatten-depth 3
 swift build 2>&1 | xcsift -f toon --toon-key-folding safe --toon-flatten-depth 2
 
-# Combine all TOON 3.0 options
+# Combine all TOON options
 xcodebuild test 2>&1 | xcsift -f toon --toon-delimiter pipe --toon-length-marker hash --toon-key-folding safe --toon-flatten-depth 5 -w -c
 ```
 
@@ -209,14 +213,14 @@ Tests are in `Tests/OutputParserTests.swift` using XCTest framework. Test cases 
   - TOON with code coverage
   - Token efficiency verification (30-60% reduction)
   - Summary-only vs details mode in TOON format
-  - **TOON 3.0 features** (7 tests):
+  - **TOON key folding features** (7 tests):
     - Key folding disabled by default
     - Key folding safe mode
     - Flatten depth default value
     - Flatten depth custom configuration
     - Key folding with build results
     - Key folding combined with flatten depth
-    - Combined TOON 3.0 configuration
+    - Combined TOON configuration
 
 Run individual tests:
 ```bash

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -103,8 +103,8 @@ struct XCSift: ParsableCommand {
         Configuration options:
           --toon-delimiter [comma|tab|pipe]  # Default: comma
           --toon-length-marker [none|hash]   # Default: none
-          --toon-key-folding [disabled|safe] # Default: disabled (TOON 3.0)
-          --toon-flatten-depth N             # Default: unlimited (TOON 3.0)
+          --toon-key-folding [disabled|safe] # Default: disabled
+          --toon-flatten-depth N             # Default: unlimited
         """,
         helpNames: [.short, .long]
     )
@@ -144,10 +144,10 @@ struct XCSift: ParsableCommand {
     @Option(name: .long, help: "TOON length marker (none or hash). Default: none")
     var toonLengthMarker: TOONLengthMarkerType = .none
 
-    @Option(name: .long, help: "TOON key folding (disabled or safe). Default: disabled. When safe, nested single-key objects collapse to dotted paths (TOON 3.0)")
+    @Option(name: .long, help: "TOON key folding (disabled or safe). Default: disabled. When safe, nested single-key objects collapse to dotted paths")
     var toonKeyFolding: TOONKeyFoldingType = .disabled
 
-    @Option(name: .long, help: "TOON flatten depth limit for key folding. Default: unlimited (TOON 3.0)")
+    @Option(name: .long, help: "TOON flatten depth limit for key folding. Default: unlimited")
     var toonFlattenDepth: Int?
 
     func run() throws {

--- a/Tests/TOONFormatTests.swift
+++ b/Tests/TOONFormatTests.swift
@@ -250,7 +250,7 @@ final class TOONFormatTests: XCTestCase {
         XCTAssertTrue(toonString!.contains("[#1]{"), "Should show [#1]{ for array of 1 element")
     }
 
-    // MARK: - TOON 3.0 Key Folding Tests
+    // MARK: - TOON Key Folding Tests
 
     func testTOONKeyFoldingDisabledByDefault() throws {
         let encoder = TOONEncoder()
@@ -326,8 +326,8 @@ final class TOONFormatTests: XCTestCase {
         XCTAssertTrue(toonString!.contains("coverage_percent: 85.5"))
     }
 
-    func testTOON30CombinedConfiguration() throws {
-        // Test combining all TOON 3.0 features
+    func testTOONCombinedConfiguration() throws {
+        // Test combining all TOON key folding features
         let parser = OutputParser()
         let input = """
         main.swift:15:5: error: use of undeclared identifier 'unknown'


### PR DESCRIPTION
This pull request updates documentation, help text, and tests to clarify and standardize terminology around the "TOON Key Folding" feature, replacing outdated "TOON 3.0" references. It also introduces and documents a new "Werror mode" for treating warnings as build errors. These changes improve clarity for users and maintainers and ensure consistency across code, documentation, and tests.

### Feature additions

* Added documentation and usage examples for "Werror mode," which treats warnings as errors and causes builds to fail if warnings are present (`README.md`, `CLAUDE.md`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R30) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R103-R106) [[3]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R49-R52)

### Documentation updates

* Replaced all references to "TOON 3.0" with "TOON Key Folding" in documentation, including option descriptions and test case lists (`README.md`, `CLAUDE.md`). [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L130-R134) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L143-R147) [[3]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L212-R223) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R145-R148) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R303-R336)
* Added a dedicated section explaining TOON Key Folding options and usage, including flatten depth configuration and combined examples (`README.md`).

### Code and CLI help text updates

* Updated CLI help text and option descriptions to use "TOON Key Folding" terminology and removed "TOON 3.0" references (`Sources/main.swift`). [[1]](diffhunk://#diff-fcc11853a9d2a44617b5433df93f033bbca46bb0d17642c65258340fea568ffcL106-R107) [[2]](diffhunk://#diff-fcc11853a9d2a44617b5433df93f033bbca46bb0d17642c65258340fea568ffcL147-R150)

### Test updates

* Renamed test sections and methods to use "TOON Key Folding" terminology instead of "TOON 3.0" (`Tests/TOONFormatTests.swift`). [[1]](diffhunk://#diff-eac251197155eb723bf9400ec613d7146427d73675021ada2abf075d9f10f61fL253-R253) [[2]](diffhunk://#diff-eac251197155eb723bf9400ec613d7146427d73675021ada2abf075d9f10f61fL329-R330)