### PR TITLE
Add DocC documentation and GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy-docc.yml
+++ b/.github/workflows/deploy-docc.yml
@@ -1,0 +1,43 @@
+name: Deploy DocC
+
+on:
+  push:
+    branches: ["master"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Build DocC
+        run: |
+          swift package --allow-writing-to-directory docs \
+              generate-documentation --target xcsift \
+              --disable-indexing \
+              --transform-for-static-hosting \
+              --hosting-base-path xcsift \
+              --output-path docs
+          echo '<script>window.location.href += "/documentation/xcsift"</script>' > docs/index.html
+
+      - uses: actions/upload-pages-artifact@v4
+        with:
+          path: 'docs'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ DerivedData/
 .swiftpm/configuration/registries.json
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
+/docs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ swift test
 ### Formatting
 **IMPORTANT:** Always run before committing changes:
 ```bash
-swift format --recursive --in-place Sources Tests
+swift format --recursive --in-place .
 ```
 
 ### Installation
@@ -408,3 +408,27 @@ When running on GitHub Actions (`GITHUB_ACTIONS=true`), xcsift automatically app
 - name: Annotations only (no JSON/TOON)
   run: xcodebuild build 2>&1 | xcsift -f github-actions
 ```
+
+## Documentation Maintenance
+
+**IMPORTANT:** When modifying public API, CLI flags, or features, you MUST update the corresponding DocC documentation in `Sources/xcsift.docc/`.
+
+Documentation files to update:
+- `xcsift.md` - Main overview and Topics structure
+- `GettingStarted.md` - Installation and basic usage
+- `Usage.md` - CLI flags and options reference
+- `OutputFormats.md` - JSON/TOON/GitHub Actions format details
+- `CodeCoverage.md` - Coverage feature documentation
+
+### Previewing Documentation Locally
+
+**For Claude:** You cannot run the preview server (it's interactive/long-running). Ask the user to run it manually.
+
+**For user:** Run in a separate terminal:
+```bash
+swift package --disable-sandbox preview-documentation --target xcsift
+```
+Opens at: http://localhost:8080/documentation/xcsift
+
+**Note:** The `docs/` folder contains pre-generated documentation for GitHub Pages with `--hosting-base-path xcsift`. Do NOT use a simple HTTP server (like `python3 -m http.server`) to serve `docs/` directly — it won't handle the `/xcsift/` base path routing.
+

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "8e823e894e580255ab0050f310402fe7e44233b051c15077bc2e607caa8e7695",
+  "originHash" : "6f2ec1107e09dc569ae9ca11ff67d9ac4215d32e4a5471034a29e5cf7222e57f",
   "pins" : [
     {
       "identity" : "swift-argument-parser",
@@ -8,6 +8,24 @@
       "state" : {
         "revision" : "309a47b2b1d9b5e991f36961c983ecec72275be3",
         "version" : "1.6.1"
+      }
+    },
+    {
+      "identity" : "swift-docc-plugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-docc-plugin",
+      "state" : {
+        "revision" : "3e4f133a77e644a5812911a0513aeb7288b07d06",
+        "version" : "1.4.5"
+      }
+    },
+    {
+      "identity" : "swift-docc-symbolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-docc-symbolkit",
+      "state" : {
+        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
+        "version" : "1.0.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -13,6 +13,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
         .package(url: "https://github.com/toon-format/toon-swift.git", from: "0.3.0"),
+        .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.4.5"),
     ],
     targets: [
         .executableTarget(

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Swift-versions](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fldomaradzki%2Fxcsift%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/ldomaradzki/xcsift)
 [![CI](https://github.com/ldomaradzki/xcsift/actions/workflows/ci.yml/badge.svg)](https://github.com/ldomaradzki/xcsift/actions/workflows/ci.yml)
 [![Release](https://github.com/ldomaradzki/xcsift/actions/workflows/release.yml/badge.svg)](https://github.com/ldomaradzki/xcsift/actions/workflows/release.yml)
+[![Docs](https://github.com/ldomaradzki/xcsift/actions/workflows/deploy-docc.yml/badge.svg)](https://ldomaradzki.github.io/xcsift/documentation/xcsift)
 [![License](https://img.shields.io/github/license/ldomaradzki/xcsift.svg)](LICENSE.md)
 
 ![Example](.github/images/example.png)
@@ -475,17 +476,52 @@ jobs:
 
 ## Development
 
+### Building
+
+```bash
+swift build
+swift build -c release
+```
+
 ### Running Tests
 
 ```bash
 swift test
 ```
 
-### Building
+### Formatting
+
+**Required before committing:**
 
 ```bash
-swift build
+swift format --recursive --in-place .
 ```
+
+### Documentation
+
+Generate DocC documentation locally:
+
+```bash
+# Build static documentation
+swift package --allow-writing-to-directory docs \
+    generate-documentation --target xcsift \
+    --disable-indexing \
+    --transform-for-static-hosting \
+    --hosting-base-path xcsift \
+    --output-path docs
+
+# Preview documentation (opens in browser at http://localhost:8080)
+swift package --disable-sandbox preview-documentation --target xcsift
+```
+
+Documentation source files are in `Sources/xcsift.docc/`:
+- `xcsift.md` — Main overview
+- `GettingStarted.md` — Installation guide
+- `Usage.md` — CLI reference
+- `OutputFormats.md` — Format details
+- `CodeCoverage.md` — Coverage feature
+
+**Production URL:** [ldomaradzki.github.io/xcsift](https://ldomaradzki.github.io/xcsift/documentation/xcsift)
 
 ## License
 

--- a/Sources/xcsift.docc/CodeCoverage.md
+++ b/Sources/xcsift.docc/CodeCoverage.md
@@ -1,0 +1,135 @@
+# Code Coverage
+
+Automatic code coverage conversion and reporting.
+
+## Overview
+
+xcsift automatically converts coverage data from both Swift Package Manager and xcodebuild formats without requiring manual llvm-cov or xccov commands.
+
+## Enabling Coverage
+
+### Swift Package Manager
+
+```bash
+swift test --enable-code-coverage 2>&1 | xcsift --coverage
+```
+
+### xcodebuild
+
+```bash
+xcodebuild test -enableCodeCoverage YES 2>&1 | xcsift --coverage
+```
+
+## Output Modes
+
+### Summary-Only (Default)
+
+By default, only the coverage percentage is included for token efficiency:
+
+```json
+{
+  "summary": {
+    "coverage_percent": 85.5
+  }
+}
+```
+
+### Details Mode
+
+Use `--coverage-details` for per-file breakdown:
+
+```bash
+swift test --enable-code-coverage 2>&1 | xcsift --coverage --coverage-details
+```
+
+Output:
+```json
+{
+  "summary": {
+    "coverage_percent": 85.5
+  },
+  "coverage": {
+    "line_coverage": 85.5,
+    "files": [
+      {
+        "path": "/path/to/ViewController.swift",
+        "name": "ViewController.swift",
+        "line_coverage": 92.5,
+        "covered_lines": 37,
+        "executable_lines": 40
+      }
+    ]
+  }
+}
+```
+
+## Auto-Detection
+
+xcsift automatically searches for coverage data in common locations:
+
+### SPM Paths
+- `.build/debug/codecov`
+- `.build/arm64-apple-macosx/debug/codecov`
+- `.build/x86_64-apple-macosx/debug/codecov`
+
+### xcodebuild Paths
+- `~/Library/Developer/Xcode/DerivedData/**/*.xcresult`
+- `./**/*.xcresult`
+
+### Custom Path
+
+Override auto-detection with `--coverage-path`:
+
+```bash
+swift test --enable-code-coverage 2>&1 | xcsift --coverage --coverage-path .build/arm64-apple-macosx/debug/codecov
+```
+
+## Automatic Conversion
+
+### SPM Coverage
+
+xcsift performs automatic conversion:
+1. Finds `.profraw` files
+2. Locates test binary
+3. Runs `llvm-profdata merge`
+4. Runs `llvm-cov export`
+
+### xcodebuild Coverage
+
+xcsift handles xcresult bundles:
+1. Finds latest `.xcresult` bundle
+2. Runs `xcrun xccov view --report --json`
+3. Extracts target from build output
+4. Filters coverage to tested target only
+
+## Target Filtering
+
+For xcodebuild, xcsift automatically extracts the tested target name from stdout and filters coverage to that target only. This prevents unrelated framework coverage from cluttering the output.
+
+If no matching coverage data is found, a warning is printed to stderr.
+
+## Platform Support
+
+| Platform | Coverage Support |
+|----------|-----------------|
+| macOS 15+ | Full support |
+| Linux (Swift 6.0+) | Not available (macOS tools required) |
+
+## TOON Format
+
+Coverage works with TOON format:
+
+```bash
+swift test --enable-code-coverage 2>&1 | xcsift -f toon --coverage
+```
+
+Summary-only TOON output:
+```toon
+status: succeeded
+summary:
+  errors: 0
+  warnings: 0
+  failed_tests: 0
+  passed_tests: 42
+  coverage_percent: 85.5
+```

--- a/Sources/xcsift.docc/GettingStarted.md
+++ b/Sources/xcsift.docc/GettingStarted.md
@@ -1,0 +1,82 @@
+# Getting Started
+
+Install xcsift and process your first build output.
+
+## Overview
+
+xcsift is a command-line tool that parses xcodebuild and Swift Package Manager output, transforming it into structured formats optimized for coding agents and LLMs.
+
+## Requirements
+
+- macOS 15.0 or later (full support including code coverage)
+- Linux with Swift 6.0+ (build/test parsing; coverage unavailable)
+
+## Installation
+
+### Using Homebrew (Recommended)
+
+```bash
+# Install from custom tap
+brew tap ldomaradzki/xcsift
+brew install xcsift
+```
+
+### Using Mint
+
+```bash
+mint install ldomaradzki/xcsift
+```
+
+### Using mise
+
+```bash
+# Install from mise registry
+mise use -g xcsift
+```
+
+### From Source
+
+```bash
+git clone https://github.com/ldomaradzki/xcsift.git
+cd xcsift
+swift build -c release
+cp .build/release/xcsift /usr/local/bin/
+```
+
+## Quick Start
+
+### Basic Build Output
+
+Pipe xcodebuild or swift build output to xcsift:
+
+```bash
+# Important: Always use 2>&1 to capture stderr
+xcodebuild build 2>&1 | xcsift
+
+# Swift Package Manager
+swift build 2>&1 | xcsift
+```
+
+### Test Output with Coverage
+
+```bash
+# SPM with coverage
+swift test --enable-code-coverage 2>&1 | xcsift --coverage
+
+# xcodebuild with coverage
+xcodebuild test -enableCodeCoverage YES 2>&1 | xcsift --coverage
+```
+
+### TOON Format for LLMs
+
+For 30-60% token reduction when passing output to LLMs:
+
+```bash
+xcodebuild build 2>&1 | xcsift --format toon
+```
+
+## What's Next
+
+- <doc:Usage> — Complete CLI reference
+- <doc:OutputFormats> — JSON, TOON, and GitHub Actions formats
+- <doc:CodeCoverage> — Automatic coverage conversion

--- a/Sources/xcsift.docc/OutputFormats.md
+++ b/Sources/xcsift.docc/OutputFormats.md
@@ -1,0 +1,171 @@
+# Output Formats
+
+Understanding JSON, TOON, and GitHub Actions output formats.
+
+## Overview
+
+xcsift supports three output formats optimized for different use cases:
+
+- **JSON** — Standard structured format, maximum compatibility
+- **TOON** — Token-efficient format for LLMs (30-60% fewer tokens)
+- **GitHub Actions** — Workflow annotations for PR integration
+
+## JSON Format
+
+The default format outputs structured JSON with build status, summary, and detailed error information.
+
+### Structure
+
+```json
+{
+  "status": "failed",
+  "summary": {
+    "errors": 1,
+    "warnings": 2,
+    "failed_tests": 0,
+    "linker_errors": 0,
+    "passed_tests": 28,
+    "build_time": "3.2",
+    "coverage_percent": 85.5
+  },
+  "errors": [
+    {
+      "file": "main.swift",
+      "line": 15,
+      "message": "use of undeclared identifier 'unknown'"
+    }
+  ]
+}
+```
+
+### Fields
+
+| Field | Description |
+|-------|-------------|
+| `status` | `"succeeded"` or `"failed"` |
+| `summary.errors` | Count of compiler errors |
+| `summary.warnings` | Count of warnings |
+| `summary.failed_tests` | Count of failed tests |
+| `summary.linker_errors` | Count of linker errors |
+| `summary.passed_tests` | Count of passed tests (if available) |
+| `summary.build_time` | Build duration in seconds |
+| `summary.coverage_percent` | Line coverage percentage (with `--coverage`) |
+
+### Optional Arrays
+
+- `errors[]` — Always included when errors exist
+- `warnings[]` — Only with `--warnings` flag
+- `linker_errors[]` — Included when linker errors detected
+- `failed_tests[]` — Included when test failures detected
+- `coverage{}` — Only with `--coverage --coverage-details`
+
+### Linker Errors
+
+Two types of linker errors are captured:
+
+**Undefined Symbols:**
+```json
+{
+  "symbol": "_OBJC_CLASS_$_MissingClass",
+  "architecture": "arm64",
+  "referenced_from": "ViewController.o",
+  "message": "",
+  "conflicting_files": []
+}
+```
+
+**Duplicate Symbols:**
+```json
+{
+  "symbol": "_globalConfiguration",
+  "architecture": "arm64",
+  "referenced_from": "",
+  "message": "",
+  "conflicting_files": ["/path/to/ConfigA.o", "/path/to/ConfigB.o"]
+}
+```
+
+## TOON Format
+
+TOON (Token-Oriented Object Notation) provides 30-60% token reduction compared to JSON, ideal for LLM consumption.
+
+### Example Output
+
+```toon
+status: failed
+summary:
+  errors: 1
+  warnings: 3
+  failed_tests: 0
+  linker_errors: 0
+errors[1]{file,line,message}:
+  main.swift,15,"use of undeclared identifier \"unknown\""
+warnings[3]{file,line,message}:
+  Parser.swift,20,"immutable value \"result\" was never used"
+  Parser.swift,25,"variable \"foo\" was never mutated"
+  Model.swift,30,"initialization of immutable value \"bar\" was never used"
+```
+
+### Features
+
+- **Tabular arrays** — Uniform arrays shown as compact tables
+- **Indentation-based** — Similar to YAML structure
+- **Human-readable** — Easy to scan while optimized for machines
+
+### Token Savings Example
+
+Same build output (1 error, 3 warnings):
+- JSON: 652 bytes
+- TOON: 447 bytes
+- **Savings: 31.4%**
+
+### Configuration Options
+
+| Option | Values | Description |
+|--------|--------|-------------|
+| `--toon-delimiter` | `comma`, `tab`, `pipe` | Table delimiter |
+| `--toon-key-folding` | `disabled`, `safe` | Collapse nested objects |
+| `--toon-flatten-depth` | Integer | Limit folding depth |
+
+## GitHub Actions Format
+
+On GitHub Actions (when `GITHUB_ACTIONS=true`), xcsift automatically appends workflow annotations after JSON/TOON output.
+
+### Behavior Matrix
+
+| Environment | Format Flag | Output |
+|-------------|-------------|--------|
+| Local | (none) | JSON |
+| Local | `-f toon` | TOON |
+| Local | `-f github-actions` | Annotations only |
+| **CI** | **(none)** | **JSON + Annotations** |
+| **CI** | **`-f toon`** | **TOON + Annotations** |
+| CI | `-f github-actions` | Annotations only |
+
+### Annotation Types
+
+```
+::error file=main.swift,line=15,col=5::use of undeclared identifier 'unknown'
+::warning file=Parser.swift,line=20,col=10::immutable value 'result' was never used
+::notice ::Build failed, 1 error, 2 warnings
+```
+
+### Workflow Example
+
+```yaml
+- name: Build
+  run: |
+    set -o pipefail
+    xcodebuild build 2>&1 | xcsift
+    # Outputs JSON + annotations automatically on CI
+```
+
+## Choosing a Format
+
+| Use Case | Recommended Format |
+|----------|-------------------|
+| LLM/AI tools | TOON (`-f toon`) |
+| JSON tooling integration | JSON (default) |
+| CI/CD with GitHub | Auto-detected |
+| Debugging | JSON with `--warnings` |
+| API cost optimization | TOON |

--- a/Sources/xcsift.docc/Usage.md
+++ b/Sources/xcsift.docc/Usage.md
@@ -1,0 +1,139 @@
+# Usage
+
+Complete CLI reference for xcsift commands and flags.
+
+## Overview
+
+xcsift reads from stdin and outputs structured build results. Always redirect stderr to stdout with `2>&1` to capture all compiler output.
+
+## Basic Syntax
+
+```bash
+xcodebuild [flags] 2>&1 | xcsift [options]
+swift build 2>&1 | xcsift [options]
+swift test 2>&1 | xcsift [options]
+```
+
+## Output Format Options
+
+### `--format`, `-f`
+
+Select output format: `json` (default), `toon`, or `github-actions`.
+
+```bash
+# JSON (default)
+xcodebuild build 2>&1 | xcsift
+
+# TOON (30-60% fewer tokens)
+xcodebuild build 2>&1 | xcsift --format toon
+xcodebuild build 2>&1 | xcsift -f toon
+
+# GitHub Actions annotations only
+xcodebuild build 2>&1 | xcsift -f github-actions
+```
+
+## Warning Options
+
+### `--warnings`, `-w`
+
+Include detailed warnings array in output. By default, only warning count is shown in summary.
+
+```bash
+# Show detailed warnings
+xcodebuild build 2>&1 | xcsift --warnings
+swift build 2>&1 | xcsift -w
+```
+
+### `--Werror`, `-W`
+
+Treat warnings as errors. Build fails if any warnings are present.
+
+```bash
+xcodebuild build 2>&1 | xcsift --Werror
+swift build 2>&1 | xcsift -W
+```
+
+## Quiet Mode
+
+### `--quiet`, `-q`
+
+Suppress output when build succeeds with no warnings or errors.
+
+```bash
+xcodebuild build 2>&1 | xcsift --quiet
+swift build 2>&1 | xcsift -q
+```
+
+## Coverage Options
+
+### `--coverage`, `-c`
+
+Enable code coverage output. Automatically converts `.profraw` (SPM) or `.xcresult` (xcodebuild) to JSON.
+
+```bash
+swift test --enable-code-coverage 2>&1 | xcsift --coverage
+xcodebuild test -enableCodeCoverage YES 2>&1 | xcsift -c
+```
+
+### `--coverage-details`
+
+Include per-file coverage breakdown. Default is summary-only (percentage only) for token efficiency.
+
+```bash
+swift test --enable-code-coverage 2>&1 | xcsift --coverage --coverage-details
+```
+
+### `--coverage-path`
+
+Specify custom path to coverage data (optional, auto-detected by default).
+
+```bash
+swift test --enable-code-coverage 2>&1 | xcsift --coverage --coverage-path .build/arm64-apple-macosx/debug/codecov
+```
+
+## TOON Configuration
+
+### `--toon-delimiter`
+
+Set delimiter for TOON tabular format: `comma` (default), `tab`, or `pipe`.
+
+```bash
+xcodebuild build 2>&1 | xcsift -f toon --toon-delimiter tab
+xcodebuild build 2>&1 | xcsift -f toon --toon-delimiter pipe
+```
+
+### `--toon-key-folding`
+
+Enable key folding: `disabled` (default) or `safe`.
+
+```bash
+# Collapses {a:{b:{c:1}}} to a.b.c: 1
+xcodebuild build 2>&1 | xcsift -f toon --toon-key-folding safe
+```
+
+### `--toon-flatten-depth`
+
+Limit key folding depth (default: unlimited).
+
+```bash
+xcodebuild build 2>&1 | xcsift -f toon --toon-key-folding safe --toon-flatten-depth 3
+```
+
+## Combined Examples
+
+```bash
+# TOON with warnings
+swift build 2>&1 | xcsift -f toon -w
+
+# TOON with coverage details
+swift test --enable-code-coverage 2>&1 | xcsift -f toon -c --coverage-details
+
+# All TOON options
+xcodebuild test 2>&1 | xcsift -f toon --toon-delimiter pipe --toon-key-folding safe -w -c
+```
+
+## Exit Codes
+
+- `0` — Build succeeded
+- `1` — Build failed (errors, linker errors, or test failures)
+- `1` — Build has warnings (when `--Werror` is used)

--- a/Sources/xcsift.docc/xcsift.md
+++ b/Sources/xcsift.docc/xcsift.md
@@ -1,0 +1,40 @@
+# ``xcsift``
+
+A Swift CLI tool to parse and format xcodebuild/SPM output for coding agents, optimized for token efficiency.
+
+## Overview
+
+xcsift transforms verbose Xcode build output into concise, structured formats that coding agents and LLMs can efficiently parse and act upon. Unlike `xcbeautify` and `xcpretty` which focus on human-readable output, xcsift prioritizes information density and machine readability.
+
+### Key Features
+
+- **Multiple output formats** — JSON (default), TOON (30-60% fewer tokens), or GitHub Actions
+- **Structured error reporting** — Clear categorization of errors, warnings, linker errors, and test failures
+- **Automatic code coverage** — Converts `.profraw` (SPM) and `.xcresult` (xcodebuild) automatically
+- **GitHub Actions integration** — Auto-detected workflow annotations with inline PR comments
+- **Token efficiency** — TOON format reduces API costs for LLM-based tools
+
+### Basic Usage
+
+```bash
+# Pipe xcodebuild output to xcsift
+xcodebuild build 2>&1 | xcsift
+
+# Use TOON format for LLM consumption
+xcodebuild build 2>&1 | xcsift --format toon
+
+# Include code coverage
+swift test --enable-code-coverage 2>&1 | xcsift --coverage
+```
+
+## Topics
+
+### Essentials
+
+- <doc:GettingStarted>
+- <doc:Usage>
+
+### Reference
+
+- <doc:OutputFormats>
+- <doc:CodeCoverage>


### PR DESCRIPTION
This pull request introduces automated DocC documentation generation and deployment for the project, along with major improvements to documentation practices and developer workflow. The most significant changes are the addition of a GitHub Actions workflow for DocC deployment, new and reorganized documentation files, and updates to developer instructions to ensure documentation remains current with public API changes.

**Documentation automation and workflow:**

* Added `.github/workflows/deploy-docc.yml` to automatically build and deploy DocC documentation to GitHub Pages on every push to `master`.
* Updated `Package.swift` to include the `swift-docc-plugin` dependency, enabling DocC documentation generation.

**Documentation content and maintenance:**

* Created comprehensive DocC documentation files in `Sources/xcsift.docc/` covering main overview (`xcsift.md`), getting started (`GettingStarted.md`), CLI usage (`Usage.md`), output formats (`OutputFormats.md`), and code coverage (`CodeCoverage.md`). [[1]](diffhunk://#diff-c834cbe89f8f5fa0d0fdd2b28887337ca76880607d1fceccf0d6dfc591d732f6R1-R40) [[2]](diffhunk://#diff-eed16a12c623e4a502222b9962263b9a11f1c9ad5fbb53f7a66221930e82401dR1-R82) [[3]](diffhunk://#diff-d70531b100c4277a22b805fbbd0b82a362b870c94b598897c2cebd832c2738d7R1-R171) [[4]](diffhunk://#diff-1c6a1d98add01283f51cc38ca868b93e66663c422aa99dccecbbf2f2326c01deR1-R135) [[5]](diffhunk://#diff-d759a990582d82f8aab321b685c5a7f037ee1518f4ad9b3f741a790282a0a84dR1-R139)
* Added clear instructions in `CLAUDE.md` for maintaining documentation: developers must update DocC files when modifying public API, CLI flags, or features, and provided guidance for previewing documentation locally.

**Developer workflow and README updates:**

* Updated `README.md` to include build, formatting, and documentation generation instructions, with direct links to the published documentation and badges for documentation status. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R8) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R479-R525)
* Improved formatting instructions in `CLAUDE.md` to simplify code formatting before commits.

These changes ensure the documentation is always up-to-date, easily accessible, and automatically published, streamlining both developer and user experience.