### PR TITLE
Add top 5 slowest targets to build info output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,6 +204,7 @@ The codebase follows a modular architecture:
   - Enabled with `--build-info` flag
   - Groups phases by target with per-target duration
   - Parses target dependency graph from xcodebuild output
+  - **Slowest Targets**: Top 5 targets sorted by duration (descending) in `slowest_targets` array
   - Supports xcodebuild phase detection from "(in target 'X' from project 'Y')" patterns
   - Supports SPM phase detection from "[N/M] Compiling/Linking TARGET" patterns
   - Parses "Build target X (Ys)" and "** BUILD SUCCEEDED ** [Xs]" patterns
@@ -297,7 +298,7 @@ Test cases cover:
     - Key folding with build results
     - Key folding combined with flatten depth
     - Combined TOON configuration
-- **Build phases, timing, and dependencies** (38 tests):
+- **Build phases, timing, and dependencies** (45 tests):
   - CompileSwiftSources phase parsing
   - SwiftDriver Compilation phase parsing
   - CompileC (Clang) phase parsing
@@ -322,6 +323,13 @@ Test cases cover:
   - Dependency graph deduplication
   - Dependencies combined with phases
   - depends_on field encoding (omitted when empty)
+  - **Slowest targets** (7 tests):
+    - Sorted by duration descending
+    - Limited to top 5
+    - Omits targets without duration
+    - Empty when no durations
+    - Encoding (omitted when empty, encoded when not)
+    - TOON format support
 
 Run individual tests:
 ```bash
@@ -392,7 +400,7 @@ The tool outputs structured data optimized for coding agents in two formats:
     - Supports both SPM (`swift test --enable-code-coverage`) and xcodebuild (`-enableCodeCoverage YES`) formats
     - Automatically detects format and parses accordingly
     - Warns to stderr if target was detected but no matching coverage data found
-  - **Build info** (with `--build-info` flag): Includes per-target phases, timing, and dependencies
+  - **Build info** (with `--build-info` flag): Includes per-target phases, timing, dependencies, and slowest targets
     ```json
     {
       "build_info": {
@@ -408,16 +416,18 @@ The tool outputs structured data optimized for coding agents in two formats:
             "phases": ["CompileSwiftSources", "Link", "CopySwiftLibs"],
             "depends_on": ["MyFramework"]
           }
-        ]
+        ],
+        "slowest_targets": ["MyApp", "MyFramework"]
       }
     }
     ```
     - Groups phases by target with per-target timing
     - Parses target dependencies from xcodebuild "Target dependency graph" output
+    - **Slowest targets**: Top 5 targets sorted by duration (descending)
     - Total build time is in `summary.build_time` (not duplicated in build_info)
     - xcodebuild phases: `CompileSwiftSources`, `SwiftCompilation`, `CompileC`, `Link`, `CopySwiftLibs`, `PhaseScriptExecution`, `LinkAssetCatalog`, `ProcessInfoPlistFile`
     - SPM phases: `Compiling`, `Linking`
-    - Empty fields are omitted (targets without phases won't have `phases` field, targets without dependencies won't have `depends_on` field)
+    - Empty fields are omitted (targets without phases won't have `phases` field, targets without dependencies won't have `depends_on` field, no `slowest_targets` when empty)
 
 ### TOON Format (with `--format toon` / `-f toon` flag)
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A Swift command-line tool to parse and format xcodebuild/SPM output for coding a
 - **Summary-only mode** - Default coverage output includes only percentage (token-efficient)
 - **Quiet mode** - Suppress output when build succeeds with no warnings or errors
 - **Werror mode** - Treat warnings as errors (build fails if warnings present)
-- **Build info** - Per-target phases and timing (CompileSwiftSources, Link, etc. with per-target duration)
+- **Build info** - Per-target phases, timing, and slowest targets (top 5 by duration)
 
 ## Installation
 
@@ -302,16 +302,18 @@ xcodebuild build 2>&1 | xcsift -f github-actions
         "duration": "23.1s",
         "phases": ["CompileSwiftSources", "Link", "CopySwiftLibs"]
       }
-    ]
+    ],
+    "slowest_targets": ["MyApp", "MyFramework"]
   }
 }
 ```
 - Groups phases by target with per-target timing
+- **Slowest targets**: Top 5 targets sorted by duration (descending)
 - Total build time is always in `summary.build_time` (not duplicated in build_info)
 - Parses xcodebuild timing from "Build target X (Ys)" patterns
 - xcodebuild phases: `CompileSwiftSources`, `SwiftCompilation`, `CompileC`, `Link`, `CopySwiftLibs`, `PhaseScriptExecution`, `LinkAssetCatalog`, `ProcessInfoPlistFile`
 - SPM phases: `Compiling`, `Linking`
-- Empty fields are omitted (targets without phases won't have `phases` field)
+- Empty fields are omitted (targets without phases won't have `phases` field, no `slowest_targets` when empty)
 
 ### TOON Format
 

--- a/Sources/Models.swift
+++ b/Sources/Models.swift
@@ -439,15 +439,31 @@ struct SlowTest: Codable {
 
 struct BuildInfo: Codable {
     let targets: [TargetBuildInfo]
+    let slowestTargets: [String]
 
-    init(targets: [TargetBuildInfo] = []) {
+    enum CodingKeys: String, CodingKey {
+        case targets
+        case slowestTargets = "slowest_targets"
+    }
+
+    init(targets: [TargetBuildInfo] = [], slowestTargets: [String] = []) {
         self.targets = targets
+        self.slowestTargets = slowestTargets
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        targets = try container.decodeIfPresent([TargetBuildInfo].self, forKey: .targets) ?? []
+        slowestTargets = try container.decodeIfPresent([String].self, forKey: .slowestTargets) ?? []
     }
 
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         if !targets.isEmpty {
             try container.encode(targets, forKey: .targets)
+        }
+        if !slowestTargets.isEmpty {
+            try container.encode(slowestTargets, forKey: .slowestTargets)
         }
     }
 }
@@ -468,6 +484,14 @@ struct TargetBuildInfo: Codable {
         self.duration = duration
         self.phases = phases
         self.dependsOn = dependsOn
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        name = try container.decode(String.self, forKey: .name)
+        duration = try container.decodeIfPresent(String.self, forKey: .duration)
+        phases = try container.decodeIfPresent([String].self, forKey: .phases) ?? []
+        dependsOn = try container.decodeIfPresent([String].self, forKey: .dependsOn) ?? []
     }
 
     func encode(to encoder: Encoder) throws {

--- a/Sources/xcsift.docc/Usage.md
+++ b/Sources/xcsift.docc/Usage.md
@@ -110,6 +110,7 @@ xcodebuild build 2>&1 | xcsift -f toon --build-info -w
 
 When enabled, output includes:
 - `build_info.targets[]` — array of targets with build information
+- `build_info.slowest_targets[]` — top 5 targets sorted by duration (descending)
 - Each target contains:
   - `name` — target name
   - `duration` — build duration (e.g., "12.4s")


### PR DESCRIPTION
## Description
Adds `slowest_targets` array to `build_info` output, showing the top 5 targets sorted by duration (descending). This feature is inspired by Tuist Argus's `trace slowest-targets` command and helps identify build bottlenecks.

- Add `slowestTargets` field to `BuildInfo` struct with proper Codable conformance
- Implement `computeSlowestTargets()` function in OutputParser to sort and limit results
- Add 8 tests covering sorting, top-5 limit, SPM output, and JSON/TOON encoding
- Update documentation in CLAUDE.md, README.md, and Usage.md