### PR TITLE
Add automatic Homebrew tap update on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,57 @@ jobs:
           path: artifacts
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: artifacts/*/xcsift-*.tar.gz
           generate_release_notes: true
+
+  update-homebrew:
+    name: Update Homebrew Tap
+    needs: release
+    runs-on: ubuntu-latest
+    # Only run if HOMEBREW_TAP_TOKEN secret is available
+    if: ${{ secrets.HOMEBREW_TAP_TOKEN != '' }}
+    steps:
+      - name: Get version from tag
+        id: version
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+      - name: Download source tarball and calculate SHA256
+        id: sha
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          curl -sL "https://github.com/ldomaradzki/xcsift/archive/refs/tags/v${VERSION}.tar.gz" -o xcsift.tar.gz
+          SHA=$(sha256sum xcsift.tar.gz | cut -d' ' -f1)
+          echo "sha256=${SHA}" >> $GITHUB_OUTPUT
+
+      - name: Checkout Homebrew tap
+        uses: actions/checkout@v5
+        with:
+          repository: ldomaradzki/homebrew-xcsift
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-xcsift
+
+      - name: Update formula
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          SHA="${{ steps.sha.outputs.sha256 }}"
+          FORMULA="homebrew-xcsift/Formula/xcsift.rb"
+
+          # Update version in URL
+          sed -i "s|/v[0-9]*\.[0-9]*\.[0-9]*\.tar\.gz|/v${VERSION}.tar.gz|" "$FORMULA"
+
+          # Update sha256
+          sed -i "s/sha256 \"[a-f0-9]*\"/sha256 \"${SHA}\"/" "$FORMULA"
+
+          echo "Updated formula:"
+          cat "$FORMULA"
+
+      - name: Commit and push
+        working-directory: homebrew-xcsift
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/xcsift.rb
+          git diff --staged --quiet || git commit -m "chore: bump to v${{ steps.version.outputs.version }}"
+          git push


### PR DESCRIPTION
## Description
Adds a new `update-homebrew` job to the release workflow that automatically updates the Homebrew formula when a new version is released.

- Add `update-homebrew` job that runs after release creation
- Download source tarball and calculate SHA256 hash
- Update formula version and sha256 in `ldomaradzki/homebrew-xcsift`
- Job is skipped if `HOMEBREW_TAP_TOKEN` secret is not configured
- Update `action-gh-release` from v1 to v2