### PR TITLE
Update CI workflows with caching and latest actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,18 @@ jobs:
     name: Build & Test (macOS)
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Select Xcode 16
         run: sudo xcode-select -s /Applications/Xcode_16.1.app/Contents/Developer
+
+      - name: Cache SPM packages
+        uses: actions/cache@v5
+        with:
+          path: .build
+          key: ${{ runner.os }}-spm-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
 
       - name: Show Swift version
         run: swift --version
@@ -34,7 +42,15 @@ jobs:
     container:
       image: swift:6.1
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
+
+      - name: Cache SPM packages
+        uses: actions/cache@v5
+        with:
+          path: .build
+          key: ${{ runner.os }}-spm-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
 
       - name: Show Swift version
         run: swift --version

--- a/.github/workflows/deploy-docc.yml
+++ b/.github/workflows/deploy-docc.yml
@@ -22,7 +22,15 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
+
+      - name: Cache SPM packages
+        uses: actions/cache@v5
+        with:
+          path: .build
+          key: ${{ runner.os }}-spm-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
 
       - name: Build DocC
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,15 @@ jobs:
         if: matrix.platform == 'linux-x64'
         run: apt-get update && apt-get install -y curl
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
+
+      - name: Cache SPM packages
+        uses: actions/cache@v5
+        with:
+          path: .build
+          key: ${{ runner.os }}-spm-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
 
       - name: Select Xcode 16 (macOS)
         if: matrix.platform == 'macos-arm64'
@@ -94,7 +102,7 @@ jobs:
           echo "sha256=${SHA}" >> $GITHUB_OUTPUT
 
       - name: Checkout Homebrew tap
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           repository: ldomaradzki/homebrew-xcsift
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}


### PR DESCRIPTION
## Description
Add SPM package caching to speed up CI builds and update GitHub Actions to their latest versions.

- Add SPM package caching via `actions/cache@v5` to all workflows (ci, deploy-docc, release)
- Update `actions/checkout` from v5 to v6
- Update `actions/cache` from v4 to v5