### PR TITLE
Update minimal versions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "xcsift",
-    platforms: [.macOS(.v15)],
+    platforms: [.macOS(.v13)],
     products: [
         .executable(
             name: "xcsift",


### PR DESCRIPTION
This pull request makes a minor update to the `Package.swift` file by lowering the minimum required macOS version for the package from 15 to 13. This change increases compatibility with older macOS systems.