### PR TITLE
Add static linking for Linux binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,8 @@ jobs:
             platform: linux-x64
             arch: x86_64
             build-path: x86_64-unknown-linux-gnu/release
-            container: swift:6.0
+            container: swift:6.0.3-jammy
+            extra-flags: --static-swift-stdlib -Xlinker -lstdc++
 
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
@@ -29,7 +30,7 @@ jobs:
     steps:
       - name: Install dependencies (Linux)
         if: matrix.platform == 'linux-x64'
-        run: apt-get update && apt-get install -y curl
+        run: apt-get update && apt-get install -y curl build-essential
 
       - uses: actions/checkout@v6
 
@@ -56,7 +57,7 @@ jobs:
           fi
 
       - name: Build release binary
-        run: swift build -c release --arch ${{ matrix.arch }}
+        run: swift build -c release --arch ${{ matrix.arch }} ${{ matrix.extra-flags }}
 
       - name: Create release archive
         run: |
@@ -91,7 +92,7 @@ jobs:
     steps:
       - name: Get version from tag
         id: version
-        run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
 
       - name: Download source tarball and calculate SHA256
         id: sha
@@ -99,7 +100,7 @@ jobs:
           VERSION="${{ steps.version.outputs.version }}"
           curl -sL "https://github.com/ldomaradzki/xcsift/archive/refs/tags/v${VERSION}.tar.gz" -o xcsift.tar.gz
           SHA=$(sha256sum xcsift.tar.gz | cut -d' ' -f1)
-          echo "sha256=${SHA}" >> $GITHUB_OUTPUT
+          echo "sha256=${SHA}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout Homebrew tap
         uses: actions/checkout@v6


### PR DESCRIPTION
This pull request updates the GitHub Actions release workflow to improve Linux build compatibility and reliability. The most significant changes involve updating the Swift container version, adding build flags for static linking, ensuring all necessary build dependencies are installed, and making minor improvements to output handling.

**Build environment and configuration improvements:**

* Updated the Linux build container from `swift:6.0` to `swift:6.0.3-jammy` for improved compatibility and stability.
* Added `extra-flags` (`--static-swift-stdlib -Xlinker -lstdc++`) to the Linux build matrix, enabling static linking of the Swift standard library and proper C++ standard library linkage. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L24-R33) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L59-R60)
* Modified the build step to include `${{ matrix.extra-flags }}` for Linux builds, ensuring the new flags are used.
* Added `build-essential` to the list of installed Linux dependencies to ensure all required build tools are available.

**Workflow reliability improvements:**

* Quoted `$GITHUB_OUTPUT` in output redirections for better shell compatibility and to avoid issues with special characters or spaces.