### PR TITLE
refactor: the way directory enumeration is handled in CoverageParser

### DIFF
--- a/Sources/CoverageParser.swift
+++ b/Sources/CoverageParser.swift
@@ -117,10 +117,11 @@ struct CoverageParser {
         }
 
         var xcresultPaths: [String] = []
-        for case let file as String in enumerator {
+        while let file = enumerator.nextObject() as? String {
             if file.hasSuffix(".xcresult") {
                 let fullPath = (directory as NSString).appendingPathComponent(file)
                 xcresultPaths.append(fullPath)
+                enumerator.skipDescendants()
             }
         }
         return xcresultPaths
@@ -193,10 +194,12 @@ struct CoverageParser {
             return nil
         }
 
-        for case let file as String in enumerator {
+        while let file = enumerator.nextObject() as? String {
             if file.hasSuffix(".xctest") {
                 let xctestPath = (buildDir as NSString).appendingPathComponent(file)
                 let macosPath = (xctestPath as NSString).appendingPathComponent("Contents/MacOS")
+
+                enumerator.skipDescendants()
 
                 guard let macosContents = try? fileSystem.contentsOfDirectory(atPath: macosPath)
                 else {


### PR DESCRIPTION
This pull request refactors the way directory enumeration is handled in `CoverageParser` to improve efficiency and correctness when searching for `.xcresult` and `.xctest` files. The main change is switching from a `for case` loop to a `while let` loop for enumerating files, and ensuring that subdirectories are not unnecessarily traversed after a relevant file is found.

**Directory enumeration improvements:**

* Replaced the `for case let file as String in enumerator` pattern with `while let file = enumerator.nextObject() as? String` for more idiomatic and efficient directory traversal in both `.xcresult` and `.xctest` searches. [[1]](diffhunk://#diff-ba79470f3f723be660256abaadb2f9448b862c276cc3210a73c7529200f29a8aL120-R124) [[2]](diffhunk://#diff-ba79470f3f723be660256abaadb2f9448b862c276cc3210a73c7529200f29a8aL196-R203)
* Added `enumerator.skipDescendants()` after finding a matching file to prevent descending into subdirectories once a relevant file is found, optimizing the search process. [[1]](diffhunk://#diff-ba79470f3f723be660256abaadb2f9448b862c276cc3210a73c7529200f29a8aL120-R124) [[2]](diffhunk://#diff-ba79470f3f723be660256abaadb2f9448b862c276cc3210a73c7529200f29a8aL196-R203)