### PR TITLE
Fix hook formats and improve plugin skills

### DIFF
--- a/Sources/Install/Templates/CursorTemplates.swift
+++ b/Sources/Install/Templates/CursorTemplates.swift
@@ -8,7 +8,7 @@ enum CursorTemplates {
         {
           "version": 1,
           "hooks": {
-            "beforeShellExecution": [
+            "preToolUse": [
               {
                 "command": "./.cursor/hooks/pre-xcsift.sh"
               }
@@ -22,7 +22,7 @@ enum CursorTemplates {
         {
           "version": 1,
           "hooks": {
-            "beforeShellExecution": [
+            "preToolUse": [
               {
                 "command": "~/.cursor/hooks/pre-xcsift.sh"
               }
@@ -34,29 +34,27 @@ enum CursorTemplates {
     /// The pre-xcsift.sh hook script content
     static let hookScript = """
         #!/bin/bash
-        # xcsift pre-shell hook for Cursor
+        # xcsift pre-tool hook for Cursor
         # Intercepts xcodebuild and swift build/test commands and pipes through xcsift
 
-        # Read the command from environment or argument
-        COMMAND="${CURSOR_SHELL_COMMAND:-$1}"
+        ALLOW='{"permission":"allow"}'
+
+        # Read tool input from stdin (JSON with tool_input field)
+        INPUT=$(cat)
+
+        # Extract the command from the tool input
+        COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 
         if [ -z "$COMMAND" ]; then
-            # No command, allow execution
-            echo '{"permission": "allow"}'
+            # No command field, allow as-is
+            echo "$ALLOW"
             exit 0
         fi
 
         # Check if xcsift is available
         if ! command -v xcsift &> /dev/null; then
             # xcsift not installed, allow command as-is
-            echo '{"permission": "allow"}'
-            exit 0
-        fi
-
-        # Check if jq is available (required for JSON output)
-        if ! command -v jq &> /dev/null; then
-            # jq not installed, allow command as-is
-            echo '{"permission": "allow"}'
+            echo "$ALLOW"
             exit 0
         fi
 
@@ -75,10 +73,10 @@ enum CursorTemplates {
             MODIFIED_COMMAND="$COMMAND | xcsift -f toon"
 
             # Return modified command
-            jq -n --arg cmd "$MODIFIED_COMMAND" '{"permission": "allow", "updatedCommand": $cmd}'
+            jq -n --arg cmd "$MODIFIED_COMMAND" '{"permission":"allow","updated_input":{"command":$cmd}}'
         else
             # Not a build command, allow as-is
-            echo '{"permission": "allow"}'
+            echo "$ALLOW"
         fi
         """
 

--- a/Sources/Install/Templates/SharedTemplates.swift
+++ b/Sources/Install/Templates/SharedTemplates.swift
@@ -7,29 +7,32 @@ enum SharedTemplates {
     static let skillMarkdown = """
         ---
         name: xcsift
-        description: Use xcsift for Swift and Xcode build output. Activate when running swift build, swift test, or xcodebuild commands. Pipe output through xcsift for structured TOON format optimized for LLM consumption.
+        description: Use xcsift for all Swift and Xcode build commands. Pipe xcodebuild build, xcodebuild test, swift build, swift test through xcsift for structured TOON output with compile errors, warnings, test failures, code coverage, slow tests, and build timing. Essential for parsing Xcode build output, diagnosing compile errors, analyzing test results, and measuring code coverage in any Swift or Xcode project.
         ---
 
         # xcsift - Xcode Build Output Formatter
 
-        xcsift is a Swift command-line tool that parses and formats xcodebuild/SPM output for coding agents. It transforms verbose Xcode build output into token-efficient TOON format optimized for machine readability.
+        xcsift parses and formats xcodebuild/SPM output into token-efficient TOON format optimized for LLM consumption. It extracts compile errors, warnings, test failures, code coverage, and build timing from verbose Xcode output.
 
         ## When to Use
 
-        Use xcsift when running Swift or Xcode build commands:
-        - `xcodebuild build`
-        - `xcodebuild test`
-        - `swift build`
-        - `swift test`
+        **Always** pipe through xcsift when running:
+        - `xcodebuild build` / `xcodebuild test`
+        - `swift build` / `swift test`
+        - Any command that produces Xcode/SPM build output
 
         ## Usage Pattern
 
-        Always pipe build output through xcsift with stderr redirected:
+        Always redirect stderr and use TOON format:
 
         ```bash
-        # Basic usage
+        # Build
         xcodebuild build 2>&1 | xcsift -f toon
         swift build 2>&1 | xcsift -f toon
+
+        # Test
+        swift test 2>&1 | xcsift -f toon
+        xcodebuild test 2>&1 | xcsift -f toon
 
         # With warnings
         xcodebuild build 2>&1 | xcsift -f toon -w
@@ -38,64 +41,85 @@ enum SharedTemplates {
         swift test --enable-code-coverage 2>&1 | xcsift -f toon -c
         xcodebuild test -enableCodeCoverage YES 2>&1 | xcsift -f toon -c
 
+        # With detailed per-file coverage
+        swift test --enable-code-coverage 2>&1 | xcsift -f toon -c --coverage-details
+
         # With executable targets
         xcodebuild build 2>&1 | xcsift -f toon -e
 
-        # Strict CI mode (fail on warnings)
+        # Strict CI mode (fail on warnings or errors)
         xcodebuild build 2>&1 | xcsift -f toon -W -E
+
+        # Slow test detection
+        swift test 2>&1 | xcsift -f toon --slow-threshold 1.0
+
+        # Build info (per-target phases, timing, dependencies)
+        xcodebuild build 2>&1 | xcsift -f toon --build-info
         ```
 
         ## Key Flags
 
         | Flag | Description |
         |------|-------------|
-        | `-f toon` | TOON format (30-60% fewer tokens) |
-        | `-w` | Show detailed warnings |
-        | `-W` | Treat warnings as errors |
-        | `-q` | Quiet mode (no output on success) |
-        | `-c` | Include code coverage |
+        | `-f toon` | TOON format (30-60% fewer tokens than JSON) |
+        | `-w` | Show detailed warnings list |
+        | `-W` | Treat warnings as errors (Werror) |
+        | `-q` | Quiet mode (no output on clean success) |
+        | `-c` | Include code coverage summary |
+        | `--coverage-details` | Per-file coverage breakdown (use with `-c`) |
         | `-e` | Include executable targets |
-        | `-E` | Exit with failure on build failure |
-        | `--build-info` | Per-target phases and timing |
+        | `-E` | Exit with non-zero code on build failure |
+        | `--build-info` | Per-target phases, timing, and dependencies |
+        | `--slow-threshold N` | Flag tests slower than N seconds |
+        | `--config PATH` | Use custom config file (default: `.xcsift.toml`) |
+        | `--init` | Generate `.xcsift.toml` template in current directory |
 
-        ## Output Format
+        ## Interpreting TOON Output
 
-        TOON format provides structured output optimized for LLMs:
+        TOON uses indentation-based structure with tabular arrays:
 
         ```toon
         status: failed
         summary:
           errors: 1
           warnings: 3
+          failed_tests: 2
+          passed_tests: 10
+          build_time: 12.4s
+          test_time: 5.2s
         errors[1]{file,line,message}:
-          main.swift,15,"use of undeclared identifier"
-        warnings[3]{file,line,message}:
-          Parser.swift,20,"unused variable"
+          main.swift,15,"use of undeclared identifier 'foo'"
+        warnings[3]{file,line,message,type}:
+          Parser.swift,20,"unused variable 'result'",compile
+          View.swift,42,"Publishing changes from background threads",swiftui
+          Util.swift,10,"Custom warning message",runtime
+        failed_tests[2]{suite,test,file,line,message,duration}:
+          MyTests,testExample,MyTests.swift,25,"XCTAssertEqual failed",0.123
+          MyTests,testOther,MyTests.swift,30,"XCTAssertTrue failed",0.456
         ```
 
-        ## Important Notes
+        **Key patterns:**
+        - `status`: `succeeded` or `failed`
+        - `errors[N]{columns}:` — tabular array with N items, column names in braces
+        - `warnings` have `type`: `compile`, `runtime`, or `swiftui`
+        - `failed_tests` include file/line for navigation and duration
+        - `null` values mean the data wasn't available
 
-        - Always use `2>&1` to capture stderr (where compiler errors are written)
+        ## Troubleshooting
+
+        | Problem | Solution |
+        |---------|----------|
+        | No errors shown but build failed | Add `2>&1` to capture stderr |
+        | Coverage shows `null` | Add `--enable-code-coverage` (SPM) or `-enableCodeCoverage YES` (xcodebuild) |
+        | "xcsift not found" | Install: `brew install xcsift` or build from source |
+        | Coverage for wrong target | xcsift auto-filters to tested target; use `--coverage-path` to override |
+        | Config not loading | Check `.xcsift.toml` in CWD or `~/.config/xcsift/config.toml` |
+
+        ## Important
+
+        - **Always use `2>&1`** to capture stderr (compiler errors and warnings go to stderr)
         - TOON format reduces tokens by 30-60% compared to raw xcodebuild output
         - When running build commands, always add `| xcsift -f toon` to the end
-
-        ## Example Workflow
-
-        1. Build the project:
-           ```bash
-           swift build 2>&1 | xcsift -f toon
-           ```
-
-        2. If build fails, analyze the structured error output
-
-        3. Run tests with coverage:
-           ```bash
-           swift test --enable-code-coverage 2>&1 | xcsift -f toon -c
-           ```
-
-        4. For CI pipelines, use strict mode:
-           ```bash
-           xcodebuild build 2>&1 | xcsift -f toon -W -E
-           ```
+        - Flaky test detection is automatic (no flag needed) — detects tests that both pass and fail
         """
 }

--- a/Tests/InstallTests.swift
+++ b/Tests/InstallTests.swift
@@ -331,7 +331,7 @@ final class CursorInstallerTests: XCTestCase {
         let template = CursorTemplates.projectHooksJSON
 
         XCTAssertTrue(template.contains("\"version\": 1"))
-        XCTAssertTrue(template.contains("beforeShellExecution"))
+        XCTAssertTrue(template.contains("preToolUse"))
         XCTAssertTrue(template.contains("./.cursor/hooks/pre-xcsift.sh"))
     }
 
@@ -339,7 +339,7 @@ final class CursorInstallerTests: XCTestCase {
         let template = CursorTemplates.globalHooksJSON
 
         XCTAssertTrue(template.contains("\"version\": 1"))
-        XCTAssertTrue(template.contains("beforeShellExecution"))
+        XCTAssertTrue(template.contains("preToolUse"))
         XCTAssertTrue(template.contains("~/.cursor/hooks/pre-xcsift.sh"))
     }
 
@@ -355,7 +355,7 @@ final class CursorInstallerTests: XCTestCase {
         XCTAssertTrue(template.contains("xcsift"))
         XCTAssertTrue(template.contains("permission"))
         XCTAssertTrue(template.contains("allow"))
-        XCTAssertTrue(template.contains("updatedCommand"))
+        XCTAssertTrue(template.contains("updated_input"))
     }
 
     func testSkillMarkdownTemplate() {

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "xcsift",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Automatically pipe xcodebuild and swift build output through xcsift for structured TOON format optimized for LLM consumption",
   "skills": "./skills"
 }

--- a/plugins/claude-code/scripts/pre-xcsift.sh
+++ b/plugins/claude-code/scripts/pre-xcsift.sh
@@ -2,7 +2,7 @@
 # xcsift pre-tool hook for Claude Code
 # Intercepts xcodebuild and swift build/test commands and pipes through xcsift
 
-set -e
+ALLOW='{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}'
 
 # Read tool input from stdin (JSON with tool_input field)
 INPUT=$(cat)
@@ -12,14 +12,14 @@ COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 
 if [ -z "$COMMAND" ]; then
     # No command field, allow as-is
-    echo '{"decision": "allow"}'
+    echo "$ALLOW"
     exit 0
 fi
 
 # Check if xcsift is available
 if ! command -v xcsift &> /dev/null; then
     # xcsift not installed, allow command as-is
-    echo '{"decision": "allow"}'
+    echo "$ALLOW"
     exit 0
 fi
 
@@ -37,9 +37,9 @@ if echo "$COMMAND" | grep -qE '^\s*(xcodebuild|swift\s+(build|test))\b' && \
     # Pipe through xcsift with TOON format
     MODIFIED_COMMAND="$COMMAND | xcsift -f toon"
 
-    # Return modified command
-    jq -n --arg cmd "$MODIFIED_COMMAND" '{"decision": "allow", "updatedCommand": $cmd}'
+    # Return modified command with rewritten input
+    jq -n --arg cmd "$MODIFIED_COMMAND" '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","updatedInput":{"command":$cmd}}}'
 else
     # Not a build command, allow as-is
-    echo '{"decision": "allow"}'
+    echo "$ALLOW"
 fi

--- a/plugins/claude-code/skills/xcsift/SKILL.md
+++ b/plugins/claude-code/skills/xcsift/SKILL.md
@@ -1,29 +1,32 @@
 ---
 name: formatting-build-output
-description: Formats xcodebuild and swift build output through xcsift into structured TOON format optimized for LLM consumption. Activates when running swift build, swift test, xcodebuild build, or xcodebuild test commands.
-version: 1.0.2
+description: Use /usr/local/bin/xcsift for all Swift and Xcode build commands. Pipe xcodebuild build, xcodebuild test, swift build, swift test through xcsift to get structured TOON output with compile errors, warnings, test failures, code coverage, slow tests, and build timing. Essential for parsing Xcode build output, diagnosing compile errors, analyzing test results, and measuring code coverage in any Swift or Xcode project.
+version: 1.0.3
 ---
 
 # xcsift - Xcode Build Output Formatter
 
-xcsift is a Swift command-line tool that parses and formats xcodebuild/SPM output for coding agents. It transforms verbose Xcode build output into token-efficient TOON format optimized for machine readability.
+xcsift parses and formats xcodebuild/SPM output into token-efficient TOON format optimized for LLM consumption. It extracts compile errors, warnings, test failures, code coverage, and build timing from verbose Xcode output.
 
 ## When to Use
 
-Use xcsift when running Swift or Xcode build commands:
-- `xcodebuild build`
-- `xcodebuild test`
-- `swift build`
-- `swift test`
+**Always** pipe through xcsift when running:
+- `xcodebuild build` / `xcodebuild test`
+- `swift build` / `swift test`
+- Any command that produces Xcode/SPM build output
 
 ## Usage Pattern
 
-Always pipe build output through xcsift with stderr redirected:
+Always redirect stderr and use TOON format:
 
 ```bash
-# Basic usage
+# Build
 xcodebuild build 2>&1 | xcsift -f toon
 swift build 2>&1 | xcsift -f toon
+
+# Test
+swift test 2>&1 | xcsift -f toon
+xcodebuild test 2>&1 | xcsift -f toon
 
 # With warnings
 xcodebuild build 2>&1 | xcsift -f toon -w
@@ -32,43 +35,83 @@ xcodebuild build 2>&1 | xcsift -f toon -w
 swift test --enable-code-coverage 2>&1 | xcsift -f toon -c
 xcodebuild test -enableCodeCoverage YES 2>&1 | xcsift -f toon -c
 
+# With detailed per-file coverage
+swift test --enable-code-coverage 2>&1 | xcsift -f toon -c --coverage-details
+
 # With executable targets
 xcodebuild build 2>&1 | xcsift -f toon -e
 
-# Strict CI mode (fail on warnings)
+# Strict CI mode (fail on warnings or errors)
 xcodebuild build 2>&1 | xcsift -f toon -W -E
+
+# Slow test detection
+swift test 2>&1 | xcsift -f toon --slow-threshold 1.0
+
+# Build info (per-target phases, timing, dependencies)
+xcodebuild build 2>&1 | xcsift -f toon --build-info
 ```
 
 ## Key Flags
 
 | Flag | Description |
 |------|-------------|
-| `-f toon` | TOON format (30-60% fewer tokens) |
-| `-w` | Show detailed warnings |
-| `-W` | Treat warnings as errors |
-| `-q` | Quiet mode (no output on success) |
-| `-c` | Include code coverage |
+| `-f toon` | TOON format (30-60% fewer tokens than JSON) |
+| `-w` | Show detailed warnings list |
+| `-W` | Treat warnings as errors (Werror) |
+| `-q` | Quiet mode (no output on clean success) |
+| `-c` | Include code coverage summary |
+| `--coverage-details` | Per-file coverage breakdown (use with `-c`) |
 | `-e` | Include executable targets |
-| `-E` | Exit with failure on build failure |
-| `--build-info` | Per-target phases and timing |
+| `-E` | Exit with non-zero code on build failure |
+| `--build-info` | Per-target phases, timing, and dependencies |
+| `--slow-threshold N` | Flag tests slower than N seconds |
+| `--config PATH` | Use custom config file (default: `.xcsift.toml`) |
+| `--init` | Generate `.xcsift.toml` template in current directory |
 
-## Output Format
+## Interpreting TOON Output
 
-TOON format provides structured output optimized for LLMs:
+TOON uses indentation-based structure with tabular arrays:
 
 ```toon
 status: failed
 summary:
   errors: 1
   warnings: 3
+  failed_tests: 2
+  passed_tests: 10
+  build_time: 12.4s
+  test_time: 5.2s
 errors[1]{file,line,message}:
-  main.swift,15,"use of undeclared identifier"
-warnings[3]{file,line,message}:
-  Parser.swift,20,"unused variable"
+  main.swift,15,"use of undeclared identifier 'foo'"
+warnings[3]{file,line,message,type}:
+  Parser.swift,20,"unused variable 'result'",compile
+  View.swift,42,"Publishing changes from background threads",swiftui
+  Util.swift,10,"Custom warning message",runtime
+failed_tests[2]{suite,test,file,line,message,duration}:
+  MyTests,testExample,MyTests.swift,25,"XCTAssertEqual failed",0.123
+  MyTests,testOther,MyTests.swift,30,"XCTAssertTrue failed",0.456
 ```
+
+**Key patterns:**
+- `status`: `succeeded` or `failed`
+- `errors[N]{columns}:` — tabular array with N items, column names in braces
+- `warnings` have `type`: `compile`, `runtime`, or `swiftui`
+- `failed_tests` include file/line for navigation and duration
+- `null` values mean the data wasn't available (e.g., `build_time: null` if not parsed)
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| No errors shown but build failed | Add `2>&1` to capture stderr |
+| Coverage shows `null` | Add `--enable-code-coverage` (SPM) or `-enableCodeCoverage YES` (xcodebuild) |
+| "xcsift not found" | Install: `brew install xcsift` or `swift build -c release && cp .build/release/xcsift /usr/local/bin/` |
+| Coverage for wrong target | xcsift auto-filters to tested target; use `--coverage-path` to override |
+| Config not loading | Check `.xcsift.toml` in CWD or `~/.config/xcsift/config.toml` |
 
 ## Important
 
-- Always use `2>&1` to capture stderr (where compiler errors are written)
+- **Always use `2>&1`** to capture stderr (compiler errors and warnings go to stderr)
 - TOON format reduces tokens by 30-60% compared to raw xcodebuild output
-- The hook automatically wraps build commands when installed
+- The pre-tool hook automatically wraps build commands when the plugin is installed
+- Flaky test detection is automatic (no flag needed) — detects tests that both pass and fail

--- a/plugins/codex/SKILL.md
+++ b/plugins/codex/SKILL.md
@@ -1,28 +1,31 @@
 ---
 name: xcsift
-description: Use xcsift for Swift and Xcode build output. Activate when running swift build, swift test, or xcodebuild commands. Pipe output through xcsift for structured TOON format optimized for LLM consumption.
+description: Use xcsift for all Swift and Xcode build commands. Pipe xcodebuild build, xcodebuild test, swift build, swift test through xcsift for structured TOON output with compile errors, warnings, test failures, code coverage, slow tests, and build timing. Essential for parsing Xcode build output, diagnosing compile errors, analyzing test results, and measuring code coverage in any Swift or Xcode project.
 ---
 
 # xcsift - Xcode Build Output Formatter
 
-xcsift is a Swift command-line tool that parses and formats xcodebuild/SPM output for coding agents. It transforms verbose Xcode build output into token-efficient TOON format optimized for machine readability.
+xcsift parses and formats xcodebuild/SPM output into token-efficient TOON format optimized for LLM consumption. It extracts compile errors, warnings, test failures, code coverage, and build timing from verbose Xcode output.
 
 ## When to Use
 
-Use xcsift when running Swift or Xcode build commands:
-- `xcodebuild build`
-- `xcodebuild test`
-- `swift build`
-- `swift test`
+**Always** pipe through xcsift when running:
+- `xcodebuild build` / `xcodebuild test`
+- `swift build` / `swift test`
+- Any command that produces Xcode/SPM build output
 
 ## Usage Pattern
 
-Always pipe build output through xcsift with stderr redirected:
+Always redirect stderr and use TOON format:
 
 ```bash
-# Basic usage
+# Build
 xcodebuild build 2>&1 | xcsift -f toon
 swift build 2>&1 | xcsift -f toon
+
+# Test
+swift test 2>&1 | xcsift -f toon
+xcodebuild test 2>&1 | xcsift -f toon
 
 # With warnings
 xcodebuild build 2>&1 | xcsift -f toon -w
@@ -31,62 +34,83 @@ xcodebuild build 2>&1 | xcsift -f toon -w
 swift test --enable-code-coverage 2>&1 | xcsift -f toon -c
 xcodebuild test -enableCodeCoverage YES 2>&1 | xcsift -f toon -c
 
+# With detailed per-file coverage
+swift test --enable-code-coverage 2>&1 | xcsift -f toon -c --coverage-details
+
 # With executable targets
 xcodebuild build 2>&1 | xcsift -f toon -e
 
-# Strict CI mode (fail on warnings)
+# Strict CI mode (fail on warnings or errors)
 xcodebuild build 2>&1 | xcsift -f toon -W -E
+
+# Slow test detection
+swift test 2>&1 | xcsift -f toon --slow-threshold 1.0
+
+# Build info (per-target phases, timing, dependencies)
+xcodebuild build 2>&1 | xcsift -f toon --build-info
 ```
 
 ## Key Flags
 
 | Flag | Description |
 |------|-------------|
-| `-f toon` | TOON format (30-60% fewer tokens) |
-| `-w` | Show detailed warnings |
-| `-W` | Treat warnings as errors |
-| `-q` | Quiet mode (no output on success) |
-| `-c` | Include code coverage |
+| `-f toon` | TOON format (30-60% fewer tokens than JSON) |
+| `-w` | Show detailed warnings list |
+| `-W` | Treat warnings as errors (Werror) |
+| `-q` | Quiet mode (no output on clean success) |
+| `-c` | Include code coverage summary |
+| `--coverage-details` | Per-file coverage breakdown (use with `-c`) |
 | `-e` | Include executable targets |
-| `-E` | Exit with failure on build failure |
-| `--build-info` | Per-target phases and timing |
+| `-E` | Exit with non-zero code on build failure |
+| `--build-info` | Per-target phases, timing, and dependencies |
+| `--slow-threshold N` | Flag tests slower than N seconds |
+| `--config PATH` | Use custom config file (default: `.xcsift.toml`) |
+| `--init` | Generate `.xcsift.toml` template in current directory |
 
-## Output Format
+## Interpreting TOON Output
 
-TOON format provides structured output optimized for LLMs:
+TOON uses indentation-based structure with tabular arrays:
 
 ```toon
 status: failed
 summary:
   errors: 1
   warnings: 3
+  failed_tests: 2
+  passed_tests: 10
+  build_time: 12.4s
+  test_time: 5.2s
 errors[1]{file,line,message}:
-  main.swift,15,"use of undeclared identifier"
-warnings[3]{file,line,message}:
-  Parser.swift,20,"unused variable"
+  main.swift,15,"use of undeclared identifier 'foo'"
+warnings[3]{file,line,message,type}:
+  Parser.swift,20,"unused variable 'result'",compile
+  View.swift,42,"Publishing changes from background threads",swiftui
+  Util.swift,10,"Custom warning message",runtime
+failed_tests[2]{suite,test,file,line,message,duration}:
+  MyTests,testExample,MyTests.swift,25,"XCTAssertEqual failed",0.123
+  MyTests,testOther,MyTests.swift,30,"XCTAssertTrue failed",0.456
 ```
 
-## Important Notes
+**Key patterns:**
+- `status`: `succeeded` or `failed`
+- `errors[N]{columns}:` — tabular array with N items, column names in braces
+- `warnings` have `type`: `compile`, `runtime`, or `swiftui`
+- `failed_tests` include file/line for navigation and duration
+- `null` values mean the data wasn't available
 
-- Always use `2>&1` to capture stderr (where compiler errors are written)
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| No errors shown but build failed | Add `2>&1` to capture stderr |
+| Coverage shows `null` | Add `--enable-code-coverage` (SPM) or `-enableCodeCoverage YES` (xcodebuild) |
+| "xcsift not found" | Install: `brew install xcsift` or `swift build -c release && cp .build/release/xcsift /usr/local/bin/` |
+| Coverage for wrong target | xcsift auto-filters to tested target; use `--coverage-path` to override |
+| Config not loading | Check `.xcsift.toml` in CWD or `~/.config/xcsift/config.toml` |
+
+## Important
+
+- **Always use `2>&1`** to capture stderr (compiler errors and warnings go to stderr)
 - TOON format reduces tokens by 30-60% compared to raw xcodebuild output
 - When running build commands, always add `| xcsift -f toon` to the end
-
-## Example Workflow
-
-1. Build the project:
-   ```bash
-   swift build 2>&1 | xcsift -f toon
-   ```
-
-2. If build fails, analyze the structured error output
-
-3. Run tests with coverage:
-   ```bash
-   swift test --enable-code-coverage 2>&1 | xcsift -f toon -c
-   ```
-
-4. For CI pipelines, use strict mode:
-   ```bash
-   xcodebuild build 2>&1 | xcsift -f toon -W -E
-   ```
+- Flaky test detection is automatic (no flag needed) — detects tests that both pass and fail

--- a/plugins/cursor/hooks.json
+++ b/plugins/cursor/hooks.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "hooks": {
-    "beforeShellExecution": [
+    "preToolUse": [
       {
         "command": "./.cursor/hooks/pre-xcsift.sh"
       }

--- a/plugins/cursor/hooks/pre-xcsift.sh
+++ b/plugins/cursor/hooks/pre-xcsift.sh
@@ -1,27 +1,25 @@
 #!/bin/bash
-# xcsift pre-shell hook for Cursor
+# xcsift pre-tool hook for Cursor
 # Intercepts xcodebuild and swift build/test commands and pipes through xcsift
 
-# Read the command from environment or argument
-COMMAND="${CURSOR_SHELL_COMMAND:-$1}"
+ALLOW='{"permission":"allow"}'
+
+# Read tool input from stdin (JSON with tool_input field)
+INPUT=$(cat)
+
+# Extract the command from the tool input
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 
 if [ -z "$COMMAND" ]; then
-    # No command, allow execution
-    echo '{"permission": "allow"}'
+    # No command field, allow as-is
+    echo "$ALLOW"
     exit 0
 fi
 
 # Check if xcsift is available
 if ! command -v xcsift &> /dev/null; then
     # xcsift not installed, allow command as-is
-    echo '{"permission": "allow"}'
-    exit 0
-fi
-
-# Check if jq is available (required for JSON output)
-if ! command -v jq &> /dev/null; then
-    # jq not installed, allow command as-is
-    echo '{"permission": "allow"}'
+    echo "$ALLOW"
     exit 0
 fi
 
@@ -40,8 +38,8 @@ if echo "$COMMAND" | grep -qE '^\s*(xcodebuild|swift\s+(build|test))\b' && \
     MODIFIED_COMMAND="$COMMAND | xcsift -f toon"
 
     # Return modified command
-    jq -n --arg cmd "$MODIFIED_COMMAND" '{"permission": "allow", "updatedCommand": $cmd}'
+    jq -n --arg cmd "$MODIFIED_COMMAND" '{"permission":"allow","updated_input":{"command":$cmd}}'
 else
     # Not a build command, allow as-is
-    echo '{"permission": "allow"}'
+    echo "$ALLOW"
 fi


### PR DESCRIPTION
## Description

Fixes #59

- **Claude Code hook**: Replace deprecated `{"decision":"allow"}` with `hookSpecificOutput` format — eliminates `PreToolUse:Bash hook error` + `(No output)` on non-build commands
- **Cursor hook**: Switch from `beforeShellExecution` to `preToolUse` — `beforeShellExecution` doesn't support command rewriting per [Cursor docs](https://cursor.com/docs/hooks). Use `updated_input` instead of `updatedCommand`
- **All skills** (Claude Code, Codex, Cursor shared template): Expand description for better triggering, add `--slow-threshold`, `--config`, `--coverage-details` flags, add "Interpreting TOON Output" and "Troubleshooting" sections
- Remove `set -e` from Claude Code hook (could cause silent exit without output)
- Bump plugin version to 1.0.3
- Update installer tests to match new templates