### PR TITLE
fix: ignore os_log/CoreData runtime noise in error parsing

### DIFF
--- a/Sources/XCSiftCore/LineParser.swift
+++ b/Sources/XCSiftCore/LineParser.swift
@@ -428,6 +428,36 @@ public struct LineParser: Sendable {
         Anchor.endOfSubject
     }
 
+    // os_log/NSLog runtime line: `YYYY-MM-DD HH:MM:SS… Process[pid:tid]…`
+    private nonisolated(unsafe) static let osLogLineRegex = Regex {
+        Anchor.startOfSubject
+        Repeat(count: 4) { One(.digit) }
+        "-"
+        Repeat(count: 2) { One(.digit) }
+        "-"
+        Repeat(count: 2) { One(.digit) }
+        " "
+        Repeat(count: 2) { One(.digit) }
+        ":"
+        Repeat(count: 2) { One(.digit) }
+        ":"
+        Repeat(count: 2) { One(.digit) }
+        OneOrMore(.any, .reluctant)
+        "["
+        OneOrMore(.digit)
+        ":"
+        OneOrMore(.digit)
+        "]"
+    }
+
+    /// App runtime logging (e.g. `2026-… App[pid:tid] [error] CoreData: error: …` or bare
+    /// `CoreData: error: …`) embeds `: error:`/`: warning:` substrings but is not a compiler
+    /// diagnostic. Skip so runtime noise never inflates error/warning counts.
+    private func isRuntimeLogNoise(_ line: String) -> Bool {
+        if line.hasPrefix(XcodebuildSymbols.coreDataLogPrefix) { return true }
+        return line.firstMatch(of: Self.osLogLineRegex) != nil
+    }
+
     // MARK: - Linker Parsing
 
     private mutating func parseLinkerLine(_ line: String) -> ParseEvent? {
@@ -769,6 +799,7 @@ public struct LineParser: Sendable {
 
     private func parseError(_ line: String) -> BuildError? {
         if isJSONLikeLine(line) { return nil }
+        if isRuntimeLogNoise(line) { return nil }
         if line.hasPrefix(" "), line.contains("|") || line.contains("`") { return nil }
 
         if let errorRange = line.range(of: XcodebuildSymbols.errorFormat) {
@@ -826,6 +857,7 @@ public struct LineParser: Sendable {
 
     private func parseWarning(_ line: String) -> BuildWarning? {
         if isJSONLikeLine(line) { return nil }
+        if isRuntimeLogNoise(line) { return nil }
         if line.hasPrefix(" "), line.contains("|") || line.contains("`") { return nil }
 
         if let warningRange = line.range(of: XcodebuildSymbols.warningFormat) {

--- a/Sources/XCSiftCore/XcodebuildSymbols.swift
+++ b/Sources/XCSiftCore/XcodebuildSymbols.swift
@@ -9,6 +9,9 @@ enum XcodebuildSymbols {
     static let fatalErrorFormat = ": Fatal error: "
     static let fatalErrorSuffix = ": Fatal error"
 
+    // Runtime log noise (os_log/NSLog output that embeds `: error:`/`: warning:` but is not a diagnostic)
+    static let coreDataLogPrefix = "CoreData: "
+
     // Fast-path filter keywords
     static let errorKeyword = "error:"
     static let warningKeyword = "warning:"

--- a/Tests/XCSiftCoreTests/ParsingTests.swift
+++ b/Tests/XCSiftCoreTests/ParsingTests.swift
@@ -1689,4 +1689,62 @@ final class ParsingTests: XCTestCase {
             "Second message should contain Comment B, got: \(result.failedTests[1].message)"
         )
     }
+
+    func testCoreDataOsLogErrorIsNoise() {
+        // os_log runtime line embedding `CoreData: error:` must not count as a build error.
+        let parser = OutputParser()
+        let input = """
+            2026-06-09 18:30:32.546476+0300 MyApp[97437:3561389] [error] CoreData: error: addPersistentStoreWithType:configuration:URL:options:error: returned error NSCocoaErrorDomain (134100)
+            Test Case 'MyTests.testExample' passed (0.001 seconds).
+            """
+
+        let result = parser.parse(input: input)
+
+        XCTAssertEqual(result.errors.count, 0)
+        XCTAssertEqual(result.status, "success")
+    }
+
+    func testBareCoreDataErrorIsNoise() {
+        // Bare CoreData runtime output (no timestamp) must not count as a build error.
+        let parser = OutputParser()
+        let input = """
+            CoreData: error: reason : The model used to open the store is incompatible
+            Test Case 'MyTests.testExample' passed (0.001 seconds).
+            """
+
+        let result = parser.parse(input: input)
+
+        XCTAssertEqual(result.errors.count, 0)
+        XCTAssertEqual(result.status, "success")
+    }
+
+    func testOsLogWarningIsNoise() {
+        // os_log runtime line embedding `: warning:` must not count as a compiler warning.
+        let parser = OutputParser()
+        let input = """
+            2026-06-09 18:30:32.546476+0300 MyApp[97437:3561389] [warning] SomeSubsystem: warning: something happened
+            Test Case 'MyTests.testExample' passed (0.001 seconds).
+            """
+
+        let result = parser.parse(input: input)
+
+        XCTAssertEqual(result.summary.warnings, 0)
+        XCTAssertEqual(result.status, "success")
+    }
+
+    func testRealErrorStillParsedAlongsideCoreDataNoise() {
+        // A genuine compiler error must survive even when CoreData noise is present.
+        let parser = OutputParser()
+        let input = """
+            2026-06-09 18:30:32.546476+0300 MyApp[97437:3561389] [error] CoreData: error: returned error NSCocoaErrorDomain (134100)
+            main.swift:15:5: error: use of undeclared identifier 'unknown'
+            """
+
+        let result = parser.parse(input: input)
+
+        XCTAssertEqual(result.errors.count, 1)
+        XCTAssertEqual(result.errors[0].file, "main.swift")
+        XCTAssertEqual(result.errors[0].line, 15)
+        XCTAssertEqual(result.status, "failed")
+    }
 }


### PR DESCRIPTION
## Problem

When an xcodebuild/SPM test log contains CoreData (or any os_log) runtime output, lines like:

```
2026-06-09 18:30:32.546476+0300 MyApp[97437:3561389] [error] CoreData: error: addPersistentStoreWithType:... returned error NSCocoaErrorDomain (134100)
CoreData: error: reason : The model used to open the store is incompatible
```

contain the `: error: ` substring that `parseError` keys off, so each runtime log line is counted as a build error. On a real integration-test log this produced **23 phantom errors** and flipped a passing run (660 passed / 0 failed) to `status: failed`.

## Fix

Add an `isRuntimeLogNoise` guard to `parseError`/`parseWarning` that skips:
- **os_log lines** — any line starting with a `YYYY-MM-DD HH:MM:SS … [pid:tid]` prefix (general: catches runtime noise from any subsystem, not just CoreData)
- **bare `CoreData:` lines** — the non-timestamped CoreData stderr output

Real compiler/linker diagnostics never carry an os_log timestamp/`[pid:tid]` prefix, so genuine errors are unaffected.

## Tests

4 new regression tests, including one proving a real `main.swift:15:5: error:` still parses correctly alongside CoreData noise. Full suite: 369 tests, 0 failures.